### PR TITLE
Ajustes de correlación entre modelos y migraciones

### DIFF
--- a/app/Models/Asignatura.php
+++ b/app/Models/Asignatura.php
@@ -10,7 +10,7 @@ class Asignatura extends Model
 {
     use HasFactory, Notifiable;
 
-    protected $table = 'asignatura';
+    protected $table = 'asignaturas';
     public $timestamps = false;
     protected $primaryKey = 'id';
 

--- a/app/Models/Carrera.php
+++ b/app/Models/Carrera.php
@@ -10,7 +10,7 @@ class Carrera extends Model
 {
     use HasFactory, Notifiable;
 
-    protected $table = 'carrera';
+    protected $table = 'carreras';
     public $timestamps = false;
     protected $primaryKey = 'id';
 

--- a/app/Models/Docente.php
+++ b/app/Models/Docente.php
@@ -10,7 +10,7 @@ class Docente extends Model
 {
     use HasFactory, Notifiable; 
 
-    protected $table = 'docente';
+    protected $table = 'docentes';
     public $timestamps = false;
     protected $primaryKey = 'id';
 

--- a/app/Models/DocenteAsignatura.php
+++ b/app/Models/DocenteAsignatura.php
@@ -8,9 +8,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class DocenteAsignatura extends Model
 {
-     use HasFactory, Notifiable;
+    use HasFactory, Notifiable;
 
-    protected $table = 'docente_asignatura';
+    protected $table = 'docente_asignaturas';
     public $timestamps = false;
     protected $primaryKey = 'id';
 

--- a/app/Models/Estudiante.php
+++ b/app/Models/Estudiante.php
@@ -9,7 +9,7 @@ class Estudiante extends Model
     use \Illuminate\Database\Eloquent\Factories\HasFactory;
 
 
-    protected $table = 'estudiante';
+    protected $table = 'estudiantes';
     public $timestamps = false;
     protected $primaryKey = 'id';
 

--- a/app/Models/Facultad.php
+++ b/app/Models/Facultad.php
@@ -10,7 +10,7 @@ class Facultad extends Model
 {
     use HasFactory, Notifiable;
 
-    protected $table = 'facultad';
+    protected $table = 'facultades';
     public $timestamps = false;
     protected $primaryKey = 'id';
 

--- a/app/Models/Solicitud.php
+++ b/app/Models/Solicitud.php
@@ -10,7 +10,7 @@ class Solicitud extends Model
 {
     use HasFactory, Notifiable;
 
-    protected $table = 'solicitud';
+    protected $table = 'solicitudes';
     public $timestamps = false;
     protected $primaryKey = 'id';
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,7 +13,7 @@ class User extends Authenticatable
     use HasFactory, Notifiable;
 
 
-    protected $table = 'usuario';
+    protected $table = 'users';
     public $timestamps = false;
     protected $primaryKey = 'id';
 

--- a/app/Models/tipoConstancia.php
+++ b/app/Models/tipoConstancia.php
@@ -10,7 +10,7 @@ class tipoConstancia extends Model
 {
     use HasFactory, Notifiable;
 
-    protected $table = 'tipo_constancia';
+    protected $table = 'tipo_constancias';
     public $timestamps = false;
     protected $primaryKey = 'id';
 

--- a/database/migrations/2025_06_08_020834_create_facultades_table.php
+++ b/database/migrations/2025_06_08_020834_create_facultades_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('facultads', function (Blueprint $table) {
+        Schema::create('facultades', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
         });
@@ -22,6 +22,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('facultads');
+        Schema::dropIfExists('facultades');
     }
 };

--- a/database/migrations/2025_06_08_022357_create_solicitudes_table.php
+++ b/database/migrations/2025_06_08_022357_create_solicitudes_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('solicituds', function (Blueprint $table) {
+        Schema::create('solicitudes', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
         });
@@ -22,6 +22,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('solicituds');
+        Schema::dropIfExists('solicitudes');
     }
 };


### PR DESCRIPTION
- Se modificaron los nombres de las tablas de singular a plural dentro de los modelos (ej. "carrera" a "carreras")
- En las migraciones se corrigieron problemas de compatibilidad generados con los comandos artisan para transformar a plural en español ("facultads" a "facultades" y "solicituds" a "solicitudes)