### PR TITLE
Migraciones actualizadas con atributos de modelos

### DIFF
--- a/database/migrations/2025_06_08_020749_create_estudiantes_table.php
+++ b/database/migrations/2025_06_08_020749_create_estudiantes_table.php
@@ -13,6 +13,9 @@ return new class extends Migration
     {
         Schema::create('estudiantes', function (Blueprint $table) {
             $table->id();
+            $table->string('cif');
+            $table->foreignId('usuario_id')->constrained('users');
+            $table->foreignId('carrera_id')->constrained('carreras');
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_06_08_020834_create_facultades_table.php
+++ b/database/migrations/2025_06_08_020834_create_facultades_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
     {
         Schema::create('facultades', function (Blueprint $table) {
             $table->id();
+            $table->string('nombre');
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_06_08_021208_create_carreras_table.php
+++ b/database/migrations/2025_06_08_021208_create_carreras_table.php
@@ -13,6 +13,8 @@ return new class extends Migration
     {
         Schema::create('carreras', function (Blueprint $table) {
             $table->id();
+            $table->string('nombre');
+            $table->foreignId('facultad_id')->constrained('facultades');
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_06_08_022357_create_solicitudes_table.php
+++ b/database/migrations/2025_06_08_022357_create_solicitudes_table.php
@@ -13,6 +13,13 @@ return new class extends Migration
     {
         Schema::create('solicitudes', function (Blueprint $table) {
             $table->id();
+            $table->date('fecha_ausencia');
+            $table->string('constancia');
+            $table->text('observaciones')->nullable();
+            $table->string('estado');
+            $table->foreignId('estudiante_id')->constrained('estudiantes');
+            $table->foreignId('docente_asignatura_id')->constrained('docente_asignaturas');
+            $table->foreignId('tipo_constancia_id')->constrained('tipo_constancias');
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_06_08_022411_create_tipo_constancias_table.php
+++ b/database/migrations/2025_06_08_022411_create_tipo_constancias_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
     {
         Schema::create('tipo_constancias', function (Blueprint $table) {
             $table->id();
+            $table->string('nombre');
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_06_08_022946_create_docentes_table.php
+++ b/database/migrations/2025_06_08_022946_create_docentes_table.php
@@ -13,6 +13,8 @@ return new class extends Migration
     {
         Schema::create('docentes', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('usuario_id')->constrained('users');
+            $table->foreignId('carrera_id')->constrained('carreras');
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_06_08_033853_create_docente_asignaturas_table.php
+++ b/database/migrations/2025_06_08_033853_create_docente_asignaturas_table.php
@@ -13,6 +13,9 @@ return new class extends Migration
     {
         Schema::create('docente_asignaturas', function (Blueprint $table) {
             $table->id();
+            $table->string('grupo');
+            $table->foreignId('docente_id')->constrained('docentes');
+            $table->foreignId('asignatura_id')->constrained('asignaturas');
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_06_08_034014_create_asignaturas_table.php
+++ b/database/migrations/2025_06_08_034014_create_asignaturas_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
     {
         Schema::create('asignaturas', function (Blueprint $table) {
             $table->id();
+            $table->string('nombre');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
- Se añadieron columnas como cif, usuario_id y carrera_id en la migración de Estudiantes para reflejar los campos del modelo.
- Se incluyó el campo nombre en la migración de Facultades para que cada facultad tenga un nombre.
- Se creó la clave foránea facultad_id y la columna nombre en la migración de Carreras.
- Se amplió la migración de Solicitudes con columnas para la fecha de ausencia, información de constancia, observaciones, estado y claves foráneas relacionadas.
- Se agregaron campos de nombre y columnas con claves foráneas en otras migraciones para que coincidan con sus modelos.