### PR TITLE
Refactor domain repositories to use domain entities

### DIFF
--- a/app/Application/Apelaciones/ApelacionService.php
+++ b/app/Application/Apelaciones/ApelacionService.php
@@ -2,11 +2,10 @@
 
 namespace App\Application\Apelaciones;
 
+use App\Domain\Apelaciones\Entities\Apelacion;
 use App\Domain\Apelaciones\Repositories\ApelacionRepository;
 use App\Enums\EstadoApelacion;
-use App\Models\ModuloEstudiante\Apelacion;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
-use Illuminate\Support\Collection;
 
 class ApelacionService
 {
@@ -14,7 +13,8 @@ class ApelacionService
     {
     }
 
-    public function listarFinalesPorEstudiante(int $estudianteId): Collection
+    /** @return iterable<Apelacion> */
+    public function listarFinalesPorEstudiante(int $estudianteId): iterable
     {
         return $this->apelaciones->listarFinalesPorEstudiante($estudianteId);
     }

--- a/app/Application/Catalogo/CatalogoService.php
+++ b/app/Application/Catalogo/CatalogoService.php
@@ -6,7 +6,6 @@ use App\Domain\Catalogo\Repositories\AsignaturaRepository;
 use App\Domain\Catalogo\Repositories\FacultadRepository;
 use App\Domain\Catalogo\Repositories\TipoConstanciaRepository;
 use App\Domain\Docente\Repositories\DocenteRepository;
-use Illuminate\Support\Collection;
 
 class CatalogoService
 {
@@ -18,32 +17,38 @@ class CatalogoService
     ) {
     }
 
-    public function docentes(): Collection
+    /** @return iterable<\App\Domain\Docente\Entities\Docente> */
+    public function docentes(): iterable
     {
         return $this->docentes->allWithUsuario();
     }
 
-    public function facultades(): Collection
+    /** @return iterable<\App\Domain\Catalogo\Entities\Facultad> */
+    public function facultades(): iterable
     {
         return $this->facultades->allOrdered();
     }
 
-    public function tiposConstancia(): Collection
+    /** @return iterable<\App\Domain\Catalogo\Entities\TipoConstancia> */
+    public function tiposConstancia(): iterable
     {
         return $this->tiposConstancia->all();
     }
 
-    public function asignaturasPorFacultad(int $facultadId): Collection
+    /** @return iterable<\App\Domain\Catalogo\Entities\Asignatura> */
+    public function asignaturasPorFacultad(int $facultadId): iterable
     {
         return $this->asignaturas->listByFacultad($facultadId);
     }
 
-    public function buscarDocentes(string $nombre, int $limit = 10): Collection
+    /** @return iterable<\App\Domain\Docente\Entities\Docente> */
+    public function buscarDocentes(string $nombre, int $limit = 10): iterable
     {
         return $this->docentes->searchByNombre($nombre, $limit);
     }
 
-    public function buscarAsignaturas(string $termino = '', ?int $facultadId = null, int $limit = 10): Collection
+    /** @return iterable<\App\Domain\Catalogo\Entities\Asignatura> */
+    public function buscarAsignaturas(string $termino = '', ?int $facultadId = null, int $limit = 10): iterable
     {
         return $this->asignaturas->search($termino, $facultadId, $limit);
     }

--- a/app/Application/Reprogramaciones/ReprogramacionService.php
+++ b/app/Application/Reprogramaciones/ReprogramacionService.php
@@ -3,11 +3,11 @@
 namespace App\Application\Reprogramaciones;
 
 use App\Application\Solicitudes\SolicitudService;
+use App\Domain\Reprogramacion\Entities\Reprogramacion;
 use App\Domain\Reprogramacion\Repositories\ReprogramacionRepository;
+use App\Domain\Solicitud\Entities\Solicitud;
 use App\Enums\EstadoAsistencia;
 use App\Mail\RescheduleMail;
-use App\Models\ModuloDocente\Reprogramacion;
-use App\Models\ModuloEstudiante\Solicitud;
 use Illuminate\Support\Facades\Mail;
 
 class ReprogramacionService

--- a/app/Application/Solicitudes/SolicitudService.php
+++ b/app/Application/Solicitudes/SolicitudService.php
@@ -2,11 +2,12 @@
 
 namespace App\Application\Solicitudes;
 
+use App\Domain\Shared\ValueObjects\ArchivoConstancia;
+use App\Domain\Solicitud\Entities\Solicitud;
 use App\Domain\Solicitud\Repositories\SolicitudRepository;
 use App\Enums\EstadoSolicitud;
 use App\Mail\ApprovalMail;
 use App\Mail\RejectionMail;
-use App\Models\ModuloEstudiante\Solicitud;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Http\UploadedFile;
@@ -33,7 +34,8 @@ class SolicitudService
     public function crear(array $data, ?UploadedFile $constancia, int $estudianteId): Solicitud
     {
         if ($constancia) {
-            $data['constancia'] = $this->publicStorage->putFile('constancias', $constancia);
+            $rutaConstancia = $this->publicStorage->putFile('constancias', $constancia);
+            $data['constancia'] = (string) new ArchivoConstancia($rutaConstancia);
         }
 
         $data['estado'] = EstadoSolicitud::Pendiente;
@@ -46,7 +48,8 @@ class SolicitudService
     {
         if ($constancia) {
             $this->eliminarConstancia($solicitud);
-            $data['constancia'] = $this->publicStorage->putFile('constancias', $constancia);
+            $rutaConstancia = $this->publicStorage->putFile('constancias', $constancia);
+            $data['constancia'] = (string) new ArchivoConstancia($rutaConstancia);
         } elseif ($eliminarConstancia) {
             $this->eliminarConstancia($solicitud);
             $data['constancia'] = null;
@@ -84,11 +87,13 @@ class SolicitudService
         return $solicitud;
     }
 
+    /** @return iterable<Solicitud> */
     public function solicitudesAprobadasSinReprogramar(int $docenteId)
     {
         return $this->solicitudes->solicitudesAprobadasSinReprogramacion($docenteId);
     }
 
+    /** @return iterable<Solicitud> */
     public function reprogramacionesPorDocente(int $docenteId)
     {
         return $this->solicitudes->reprogramacionesPorDocente($docenteId);

--- a/app/Domain/Apelaciones/Entities/Apelacion.php
+++ b/app/Domain/Apelaciones/Entities/Apelacion.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace App\Models\ModuloEstudiante;
+namespace App\Domain\Apelaciones\Entities;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Domain\Solicitud\Entities\Solicitud;
 use App\Enums\EstadoApelacion;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 
 class Apelacion extends Model
 {
@@ -33,12 +34,12 @@ class Apelacion extends Model
 
     public function apelacionPadre()
     {
-        return $this->belongsTo(Apelacion::class, 'apelacion_id', 'id');
+        return $this->belongsTo(self::class, 'apelacion_id', 'id');
     }
 
     public function apelacionesHijas()
     {
-        return $this->hasMany(Apelacion::class, 'apelacion_id', 'id');
+        return $this->hasMany(self::class, 'apelacion_id', 'id');
     }
 
     /**
@@ -74,3 +75,5 @@ class Apelacion extends Model
         return $historial;
     }
 }
+
+\class_alias(Apelacion::class, 'App\\Models\\ModuloEstudiante\\Apelacion');

--- a/app/Domain/Apelaciones/Repositories/ApelacionRepository.php
+++ b/app/Domain/Apelaciones/Repositories/ApelacionRepository.php
@@ -2,14 +2,14 @@
 
 namespace App\Domain\Apelaciones\Repositories;
 
+use App\Domain\Apelaciones\Entities\Apelacion;
 use App\Enums\EstadoApelacion;
-use App\Models\ModuloEstudiante\Apelacion;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
-use Illuminate\Support\Collection;
 
 interface ApelacionRepository
 {
-    public function listarFinalesPorEstudiante(int $estudianteId): Collection;
+    /** @return iterable<Apelacion> */
+    public function listarFinalesPorEstudiante(int $estudianteId): iterable;
 
     public function obtenerUltimaPorSolicitud(int $solicitudId): ?Apelacion;
 

--- a/app/Domain/Catalogo/Entities/Asignatura.php
+++ b/app/Domain/Catalogo/Entities/Asignatura.php
@@ -1,14 +1,11 @@
 <?php
 
-namespace App\Models\ModuloSecretaria;
+namespace App\Domain\Catalogo\Entities;
 
+use App\Domain\Solicitud\Entities\Solicitud;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-
-// Models
-use App\Models\ModuloSecretaria\Facultad;
-use App\Models\ModuloEstudiante\Solicitud;
 
 class Asignatura extends Model
 {
@@ -33,3 +30,5 @@ class Asignatura extends Model
         return $this->hasMany(Solicitud::class, 'asignatura_id', 'id');
     }
 }
+
+\class_alias(Asignatura::class, 'App\\Models\\ModuloSecretaria\\Asignatura');

--- a/app/Domain/Catalogo/Entities/Carrera.php
+++ b/app/Domain/Catalogo/Entities/Carrera.php
@@ -1,15 +1,11 @@
 <?php
 
-namespace App\Models\ModuloSecretaria;
+namespace App\Domain\Catalogo\Entities;
 
-use Illuminate\Database\Eloquent\Model;
+use App\Domain\Estudiante\Entities\Estudiante;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
-
-// Models
-use App\Models\ModuloEstudiante\Estudiante;
-
-use App\Models\ModuloSecretaria\Facultad;
 
 class Carrera extends Model
 {
@@ -36,3 +32,5 @@ class Carrera extends Model
         return $this->belongsTo(Facultad::class, 'facultad_id', 'id');
     }
 }
+
+\class_alias(Carrera::class, 'App\\Models\\ModuloSecretaria\\Carrera');

--- a/app/Domain/Catalogo/Entities/Facultad.php
+++ b/app/Domain/Catalogo/Entities/Facultad.php
@@ -1,14 +1,10 @@
 <?php
 
-namespace App\Models\ModuloSecretaria;
+namespace App\Domain\Catalogo\Entities;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
-
-// Models
-use App\Models\ModuloSecretaria\Carrera;
-use App\Models\ModuloSecretaria\Asignatura;
 
 class Facultad extends Model
 {
@@ -33,3 +29,5 @@ class Facultad extends Model
         return $this->hasMany(Asignatura::class, 'facultad_id', 'id');
     }
 }
+
+\class_alias(Facultad::class, 'App\\Models\\ModuloSecretaria\\Facultad');

--- a/app/Domain/Catalogo/Entities/TipoConstancia.php
+++ b/app/Domain/Catalogo/Entities/TipoConstancia.php
@@ -1,13 +1,11 @@
 <?php
 
-namespace App\Models\ModuloSecretaria;
+namespace App\Domain\Catalogo\Entities;
 
+use App\Domain\Solicitud\Entities\Solicitud;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-
-// Models
-use App\Models\ModuloEstudiante\Solicitud;
 
 class TipoConstancia extends Model
 {
@@ -27,5 +25,6 @@ class TipoConstancia extends Model
     {
         return $this->hasMany(Solicitud::class, 'tipo_constancia_id', 'id');
     }
-
 }
+
+\class_alias(TipoConstancia::class, 'App\\Models\\ModuloSecretaria\\TipoConstancia');

--- a/app/Domain/Catalogo/Repositories/AsignaturaRepository.php
+++ b/app/Domain/Catalogo/Repositories/AsignaturaRepository.php
@@ -2,11 +2,13 @@
 
 namespace App\Domain\Catalogo\Repositories;
 
-use Illuminate\Support\Collection;
+use App\Domain\Catalogo\Entities\Asignatura;
 
 interface AsignaturaRepository
 {
-    public function listByFacultad(int $facultadId): Collection;
+    /** @return iterable<Asignatura> */
+    public function listByFacultad(int $facultadId): iterable;
 
-    public function search(string $termino = '', ?int $facultadId = null, int $limit = 10): Collection;
+    /** @return iterable<Asignatura> */
+    public function search(string $termino = '', ?int $facultadId = null, int $limit = 10): iterable;
 }

--- a/app/Domain/Catalogo/Repositories/FacultadRepository.php
+++ b/app/Domain/Catalogo/Repositories/FacultadRepository.php
@@ -2,9 +2,10 @@
 
 namespace App\Domain\Catalogo\Repositories;
 
-use Illuminate\Support\Collection;
+use App\Domain\Catalogo\Entities\Facultad;
 
 interface FacultadRepository
 {
-    public function allOrdered(): Collection;
+    /** @return iterable<Facultad> */
+    public function allOrdered(): iterable;
 }

--- a/app/Domain/Catalogo/Repositories/TipoConstanciaRepository.php
+++ b/app/Domain/Catalogo/Repositories/TipoConstanciaRepository.php
@@ -2,9 +2,10 @@
 
 namespace App\Domain\Catalogo\Repositories;
 
-use Illuminate\Support\Collection;
+use App\Domain\Catalogo\Entities\TipoConstancia;
 
 interface TipoConstanciaRepository
 {
-    public function all(): Collection;
+    /** @return iterable<TipoConstancia> */
+    public function all(): iterable;
 }

--- a/app/Domain/Docente/Entities/Docente.php
+++ b/app/Domain/Docente/Entities/Docente.php
@@ -1,30 +1,24 @@
 <?php
 
-namespace App\Models\ModuloSecretaria;
+namespace App\Domain\Docente\Entities;
 
+use App\Domain\Solicitud\Entities\Solicitud;
+use App\Domain\Usuarios\Entities\User;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use \Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Notifications\Notifiable;
-
-// Models
-use App\Models\User;
-
-use App\Models\ModuloEstudiante\Solicitud;
-
 
 class Docente extends Model
 {
-    use HasFactory, Notifiable; 
+    use HasFactory, Notifiable;
 
     protected $table = 'docentes';
     public $timestamps = false;
     protected $primaryKey = 'id';
 
-
     protected $fillable = [
         'cif',
         'usuario_id',
-
     ];
 
     // Relaciones
@@ -33,9 +27,11 @@ class Docente extends Model
     {
         return $this->belongsTo(User::class, 'usuario_id', 'id');
     }
-    
+
     public function solicitudes()
     {
         return $this->hasMany(Solicitud::class, 'docente_id', 'id');
     }
 }
+
+\class_alias(Docente::class, 'App\\Models\\ModuloSecretaria\\Docente');

--- a/app/Domain/Docente/Repositories/DocenteRepository.php
+++ b/app/Domain/Docente/Repositories/DocenteRepository.php
@@ -2,11 +2,13 @@
 
 namespace App\Domain\Docente\Repositories;
 
-use Illuminate\Support\Collection;
+use App\Domain\Docente\Entities\Docente;
 
 interface DocenteRepository
 {
-    public function allWithUsuario(): Collection;
+    /** @return iterable<Docente> */
+    public function allWithUsuario(): iterable;
 
-    public function searchByNombre(string $nombre, int $limit = 10): Collection;
+    /** @return iterable<Docente> */
+    public function searchByNombre(string $nombre, int $limit = 10): iterable;
 }

--- a/app/Domain/Estudiante/Entities/Estudiante.php
+++ b/app/Domain/Estudiante/Entities/Estudiante.php
@@ -1,36 +1,30 @@
 <?php
 
-namespace App\Models\ModuloEstudiante;
+namespace App\Domain\Estudiante\Entities;
 
+use App\Domain\Catalogo\Entities\Carrera;
+use App\Domain\Solicitud\Entities\Solicitud;
+use App\Domain\Usuarios\Entities\User;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-
-// Models
-use App\Models\User;
-use App\Models\ModuloSecretaria\Carrera;
-use App\Models\ModuloEstudiante\Solicitud;
 
 class Estudiante extends Model
 {
-    use \Illuminate\Database\Eloquent\Factories\HasFactory;
-
+    use HasFactory;
 
     protected $table = 'estudiantes';
     public $timestamps = false;
     protected $primaryKey = 'id';
 
-    
-
     /**
-     * The attributes that are mass assignable.
-     *
      * @var array<string>
      */
     protected $fillable = [
         'cif',
         'usuario_id',
-        'carrera_id'
+        'carrera_id',
     ];
-    
+
     // Relaciones
 
     public function usuario()
@@ -48,3 +42,5 @@ class Estudiante extends Model
         return $this->hasMany(Solicitud::class, 'estudiante_id', 'id');
     }
 }
+
+\class_alias(Estudiante::class, 'App\\Models\\ModuloEstudiante\\Estudiante');

--- a/app/Domain/Reprogramacion/Entities/Reprogramacion.php
+++ b/app/Domain/Reprogramacion/Entities/Reprogramacion.php
@@ -1,13 +1,11 @@
 <?php
 
-namespace App\Models\ModuloDocente;
+namespace App\Domain\Reprogramacion\Entities;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Domain\Solicitud\Entities\Solicitud;
 use App\Enums\EstadoAsistencia;
-
-// Models
-use App\Models\ModuloEstudiante\Solicitud;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 
 class Reprogramacion extends Model
 {
@@ -38,3 +36,5 @@ class Reprogramacion extends Model
         return $this->belongsTo(Solicitud::class, 'solicitud_id', 'id');
     }
 }
+
+\class_alias(Reprogramacion::class, 'App\\Models\\ModuloDocente\\Reprogramacion');

--- a/app/Domain/Reprogramacion/Repositories/ReprogramacionRepository.php
+++ b/app/Domain/Reprogramacion/Repositories/ReprogramacionRepository.php
@@ -2,7 +2,7 @@
 
 namespace App\Domain\Reprogramacion\Repositories;
 
-use App\Models\ModuloDocente\Reprogramacion;
+use App\Domain\Reprogramacion\Entities\Reprogramacion;
 
 interface ReprogramacionRepository
 {

--- a/app/Domain/Seguridad/Entities/Role.php
+++ b/app/Domain/Seguridad/Entities/Role.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace App\Models\ModuloSeguridad;
+namespace App\Domain\Seguridad\Entities;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 
 class Role extends Model
 {
@@ -13,3 +13,5 @@ class Role extends Model
     public $timestamps = false;
     protected $fillable = ['name'];
 }
+
+\class_alias(Role::class, 'App\\Models\\ModuloSeguridad\\Role');

--- a/app/Domain/Shared/ValueObjects/ArchivoConstancia.php
+++ b/app/Domain/Shared/ValueObjects/ArchivoConstancia.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Domain\Shared\ValueObjects;
+
+use InvalidArgumentException;
+
+final class ArchivoConstancia
+{
+    private const EXTENSIONES_PERMITIDAS = ['pdf', 'jpg', 'jpeg', 'png'];
+
+    public function __construct(private readonly string $ruta)
+    {
+        $extension = strtolower(pathinfo($ruta, PATHINFO_EXTENSION));
+
+        if ($extension === '') {
+            throw new InvalidArgumentException('El archivo de constancia debe tener una extensión.');
+        }
+
+        if (! in_array($extension, self::EXTENSIONES_PERMITIDAS, true)) {
+            throw new InvalidArgumentException('Extensión de constancia no permitida.');
+        }
+    }
+
+    public function ruta(): string
+    {
+        return $this->ruta;
+    }
+
+    public function extension(): string
+    {
+        return strtolower(pathinfo($this->ruta, PATHINFO_EXTENSION));
+    }
+
+    public function __toString(): string
+    {
+        return $this->ruta;
+    }
+}

--- a/app/Domain/Shared/ValueObjects/EmailInstitucional.php
+++ b/app/Domain/Shared/ValueObjects/EmailInstitucional.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Domain\Shared\ValueObjects;
+
+use InvalidArgumentException;
+
+final class EmailInstitucional
+{
+    public function __construct(private readonly string $value)
+    {
+        if (filter_var($value, FILTER_VALIDATE_EMAIL) === false) {
+            throw new InvalidArgumentException('El correo institucional proporcionado no es válido.');
+        }
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/app/Domain/Solicitud/Entities/Solicitud.php
+++ b/app/Domain/Solicitud/Entities/Solicitud.php
@@ -1,19 +1,17 @@
 <?php
 
-namespace App\Models\ModuloEstudiante;
+namespace App\Domain\Solicitud\Entities;
 
+use App\Domain\Apelaciones\Entities\Apelacion;
+use App\Domain\Catalogo\Entities\Asignatura;
+use App\Domain\Catalogo\Entities\TipoConstancia;
+use App\Domain\Docente\Entities\Docente;
+use App\Domain\Estudiante\Entities\Estudiante;
+use App\Domain\Reprogramacion\Entities\Reprogramacion;
+use App\Enums\EstadoSolicitud;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-
-// Models
-use App\Models\ModuloEstudiante\Estudiante;
-use App\Models\ModuloEstudiante\Apelacion;
-use App\Models\ModuloSecretaria\TipoConstancia;
-use App\Models\ModuloDocente\Reprogramacion;
-use App\Enums\EstadoSolicitud;
-use App\Models\ModuloSecretaria\Docente;
-use App\Models\ModuloSecretaria\Asignatura;
 
 class Solicitud extends Model
 {
@@ -75,3 +73,5 @@ class Solicitud extends Model
         return $this->hasOne(Reprogramacion::class, 'solicitud_id', 'id');
     }
 }
+
+\class_alias(Solicitud::class, 'App\\Models\\ModuloEstudiante\\Solicitud');

--- a/app/Domain/Solicitud/Repositories/SolicitudRepository.php
+++ b/app/Domain/Solicitud/Repositories/SolicitudRepository.php
@@ -2,10 +2,9 @@
 
 namespace App\Domain\Solicitud\Repositories;
 
+use App\Domain\Solicitud\Entities\Solicitud;
 use App\Enums\EstadoSolicitud;
-use App\Models\ModuloEstudiante\Solicitud;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
-use Illuminate\Support\Collection;
 
 interface SolicitudRepository
 {
@@ -19,7 +18,9 @@ interface SolicitudRepository
 
     public function delete(Solicitud $solicitud): void;
 
-    public function solicitudesAprobadasSinReprogramacion(int $docenteId): Collection;
+    /** @return iterable<Solicitud> */
+    public function solicitudesAprobadasSinReprogramacion(int $docenteId): iterable;
 
-    public function reprogramacionesPorDocente(int $docenteId): Collection;
+    /** @return iterable<Solicitud> */
+    public function reprogramacionesPorDocente(int $docenteId): iterable;
 }

--- a/app/Domain/Usuarios/Entities/User.php
+++ b/app/Domain/Usuarios/Entities/User.php
@@ -1,30 +1,27 @@
 <?php
 
-namespace App\Models;
+namespace App\Domain\Usuarios\Entities;
 
+use App\Domain\Docente\Entities\Docente;
+use App\Domain\Estudiante\Entities\Estudiante;
+use App\Domain\Seguridad\Entities\Role;
+use App\Notifications\CustomResetPassword;
+use App\Notifications\CustomVerifyEmail;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use App\Models\ModuloSeguridad\Role;
-use App\Models\ModuloEstudiante\Estudiante;
-use App\Models\ModuloSecretaria\Docente;
-use App\Notifications\CustomVerifyEmail;
-use App\Notifications\CustomResetPassword;
 
 class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable;
 
-
     protected $table = 'users';
     public $timestamps = false;
     protected $primaryKey = 'id';
 
     /**
-     * The attributes that are mass assignable.
-     *
      * @var list<string>
      */
     protected $fillable = [
@@ -35,8 +32,6 @@ class User extends Authenticatable implements MustVerifyEmail
     ];
 
     /**
-     * The attributes that should be hidden for serialization.
-     *
      * @var list<string>
      */
     protected $hidden = [
@@ -45,8 +40,6 @@ class User extends Authenticatable implements MustVerifyEmail
     ];
 
     /**
-     * Get the attributes that should be cast.
-     *
      * @return array<string, string>
      */
     protected function casts(): array
@@ -57,8 +50,7 @@ class User extends Authenticatable implements MustVerifyEmail
         ];
     }
 
-
-     // Relaciones
+    // Relaciones
 
     public function estudiante()
     {
@@ -80,22 +72,15 @@ class User extends Authenticatable implements MustVerifyEmail
         return $this->role?->name === $roleName;
     }
 
-    /**
-     * Send the custom email verification notification.
-     */
     public function sendEmailVerificationNotification(): void
     {
         $this->notify(new CustomVerifyEmail());
     }
 
-        /**
-     * Send the password reset notification.
-     */
     public function sendPasswordResetNotification($token): void
     {
         $this->notify(new CustomResetPassword($token));
     }
-
-
-
 }
+
+\class_alias(User::class, 'App\\Models\\User');

--- a/app/Infraestructure/Imports/AsignaturasImport.php
+++ b/app/Infraestructure/Imports/AsignaturasImport.php
@@ -2,7 +2,7 @@
 
 namespace App\Imports;
 
-use App\Models\ModuloSecretaria\Asignatura;
+use App\Domain\Catalogo\Entities\Asignatura;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithHeadingRow;
 

--- a/app/Infraestructure/Imports/DocentesImport.php
+++ b/app/Infraestructure/Imports/DocentesImport.php
@@ -2,10 +2,9 @@
 
 namespace App\Imports;
 
-use App\Models\ModuloSecretaria\Docente;
-use App\Models\User;
-use App\Models\ModuloSeguridad\Role;
-use Illuminate\Support\Facades\Password;
+use App\Domain\Docente\Entities\Docente;
+use App\Domain\Seguridad\Entities\Role;
+use App\Domain\Usuarios\Entities\User;
 use Illuminate\Support\Str;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithHeadingRow;

--- a/app/Infraestructure/Mail/ApprovalMail.php
+++ b/app/Infraestructure/Mail/ApprovalMail.php
@@ -2,13 +2,13 @@
 
 namespace App\Mail;
 
+use App\Domain\Solicitud\Entities\Solicitud;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
-use App\Models\ModuloEstudiante\Solicitud;
 
 class ApprovalMail extends Mailable implements ShouldQueue
 {

--- a/app/Infraestructure/Persistence/Eloquent/Repositories/EloquentApelacionRepository.php
+++ b/app/Infraestructure/Persistence/Eloquent/Repositories/EloquentApelacionRepository.php
@@ -2,15 +2,14 @@
 
 namespace App\Infraestructure\Persistence\Eloquent\Repositories;
 
+use App\Domain\Apelaciones\Entities\Apelacion;
 use App\Domain\Apelaciones\Repositories\ApelacionRepository;
 use App\Enums\EstadoApelacion;
-use App\Models\ModuloEstudiante\Apelacion;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
-use Illuminate\Support\Collection;
 
 class EloquentApelacionRepository implements ApelacionRepository
 {
-    public function listarFinalesPorEstudiante(int $estudianteId): Collection
+    public function listarFinalesPorEstudiante(int $estudianteId): iterable
     {
         return Apelacion::whereDoesntHave('apelacionesHijas')
             ->whereHas('solicitud', fn($q) => $q->where('estudiante_id', $estudianteId))

--- a/app/Infraestructure/Persistence/Eloquent/Repositories/EloquentAsignaturaRepository.php
+++ b/app/Infraestructure/Persistence/Eloquent/Repositories/EloquentAsignaturaRepository.php
@@ -2,20 +2,19 @@
 
 namespace App\Infraestructure\Persistence\Eloquent\Repositories;
 
+use App\Domain\Catalogo\Entities\Asignatura;
 use App\Domain\Catalogo\Repositories\AsignaturaRepository;
-use App\Models\ModuloSecretaria\Asignatura;
-use Illuminate\Support\Collection;
 
 class EloquentAsignaturaRepository implements AsignaturaRepository
 {
-    public function listByFacultad(int $facultadId): Collection
+    public function listByFacultad(int $facultadId): iterable
     {
         return Asignatura::where('facultad_id', $facultadId)
             ->orderBy('nombre')
             ->get(['id', 'nombre']);
     }
 
-    public function search(string $termino = '', ?int $facultadId = null, int $limit = 10): Collection
+    public function search(string $termino = '', ?int $facultadId = null, int $limit = 10): iterable
     {
         return Asignatura::query()
             ->when($facultadId, fn($q) => $q->where('facultad_id', $facultadId))

--- a/app/Infraestructure/Persistence/Eloquent/Repositories/EloquentDocenteRepository.php
+++ b/app/Infraestructure/Persistence/Eloquent/Repositories/EloquentDocenteRepository.php
@@ -2,18 +2,17 @@
 
 namespace App\Infraestructure\Persistence\Eloquent\Repositories;
 
+use App\Domain\Docente\Entities\Docente;
 use App\Domain\Docente\Repositories\DocenteRepository;
-use App\Models\ModuloSecretaria\Docente;
-use Illuminate\Support\Collection;
 
 class EloquentDocenteRepository implements DocenteRepository
 {
-    public function allWithUsuario(): Collection
+    public function allWithUsuario(): iterable
     {
         return Docente::with('usuario')->get();
     }
 
-    public function searchByNombre(string $nombre, int $limit = 10): Collection
+    public function searchByNombre(string $nombre, int $limit = 10): iterable
     {
         return Docente::with('usuario')
             ->when($nombre !== '', function ($query) use ($nombre) {

--- a/app/Infraestructure/Persistence/Eloquent/Repositories/EloquentFacultadRepository.php
+++ b/app/Infraestructure/Persistence/Eloquent/Repositories/EloquentFacultadRepository.php
@@ -2,13 +2,12 @@
 
 namespace App\Infraestructure\Persistence\Eloquent\Repositories;
 
+use App\Domain\Catalogo\Entities\Facultad;
 use App\Domain\Catalogo\Repositories\FacultadRepository;
-use App\Models\ModuloSecretaria\Facultad;
-use Illuminate\Support\Collection;
 
 class EloquentFacultadRepository implements FacultadRepository
 {
-    public function allOrdered(): Collection
+    public function allOrdered(): iterable
     {
         return Facultad::orderBy('nombre')->get();
     }

--- a/app/Infraestructure/Persistence/Eloquent/Repositories/EloquentReprogramacionRepository.php
+++ b/app/Infraestructure/Persistence/Eloquent/Repositories/EloquentReprogramacionRepository.php
@@ -2,8 +2,8 @@
 
 namespace App\Infraestructure\Persistence\Eloquent\Repositories;
 
+use App\Domain\Reprogramacion\Entities\Reprogramacion;
 use App\Domain\Reprogramacion\Repositories\ReprogramacionRepository;
-use App\Models\ModuloDocente\Reprogramacion;
 
 class EloquentReprogramacionRepository implements ReprogramacionRepository
 {

--- a/app/Infraestructure/Persistence/Eloquent/Repositories/EloquentSolicitudRepository.php
+++ b/app/Infraestructure/Persistence/Eloquent/Repositories/EloquentSolicitudRepository.php
@@ -2,12 +2,11 @@
 
 namespace App\Infraestructure\Persistence\Eloquent\Repositories;
 
+use App\Domain\Solicitud\Entities\Solicitud;
 use App\Domain\Solicitud\Repositories\SolicitudRepository;
 use App\Enums\EstadoApelacion;
 use App\Enums\EstadoSolicitud;
-use App\Models\ModuloEstudiante\Solicitud;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
-use Illuminate\Support\Collection;
 
 class EloquentSolicitudRepository implements SolicitudRepository
 {
@@ -53,7 +52,7 @@ class EloquentSolicitudRepository implements SolicitudRepository
         $solicitud->delete();
     }
 
-    public function solicitudesAprobadasSinReprogramacion(int $docenteId): Collection
+    public function solicitudesAprobadasSinReprogramacion(int $docenteId): iterable
     {
         return Solicitud::with(['estudiante.usuario', 'asignatura'])
             ->where('estado', EstadoSolicitud::Aprobada)
@@ -63,7 +62,7 @@ class EloquentSolicitudRepository implements SolicitudRepository
             ->get();
     }
 
-    public function reprogramacionesPorDocente(int $docenteId): Collection
+    public function reprogramacionesPorDocente(int $docenteId): iterable
     {
         return Solicitud::with(['reprogramacion', 'estudiante.usuario', 'asignatura'])
             ->where('docente_id', $docenteId)

--- a/app/Infraestructure/Persistence/Eloquent/Repositories/EloquentTipoConstanciaRepository.php
+++ b/app/Infraestructure/Persistence/Eloquent/Repositories/EloquentTipoConstanciaRepository.php
@@ -2,13 +2,12 @@
 
 namespace App\Infraestructure\Persistence\Eloquent\Repositories;
 
+use App\Domain\Catalogo\Entities\TipoConstancia;
 use App\Domain\Catalogo\Repositories\TipoConstanciaRepository;
-use App\Models\ModuloSecretaria\TipoConstancia;
-use Illuminate\Support\Collection;
 
 class EloquentTipoConstanciaRepository implements TipoConstanciaRepository
 {
-    public function all(): Collection
+    public function all(): iterable
     {
         return TipoConstancia::orderBy('nombre')->get();
     }

--- a/app/Infraestructure/Persistence/seeders/AsignaturasSeeder.php
+++ b/app/Infraestructure/Persistence/seeders/AsignaturasSeeder.php
@@ -2,9 +2,9 @@
 
 namespace Database\Seeders;
 
+use App\Domain\Catalogo\Entities\Asignatura;
+use App\Domain\Catalogo\Entities\Facultad;
 use Illuminate\Database\Seeder;
-use App\Models\ModuloSecretaria\Asignatura;
-use App\Models\ModuloSecretaria\Facultad;
 
 class AsignaturasSeeder extends Seeder
 {

--- a/app/Infraestructure/Persistence/seeders/DatabaseSeeder.php
+++ b/app/Infraestructure/Persistence/seeders/DatabaseSeeder.php
@@ -2,16 +2,12 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
+use App\Domain\Catalogo\Entities\Carrera;
+use App\Domain\Catalogo\Entities\Facultad;
+use App\Domain\Estudiante\Entities\Estudiante;
+use App\Domain\Seguridad\Entities\Role;
+use App\Domain\Usuarios\Entities\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
-use Database\Seeders\FacultadesSeeder;
-use Database\Seeders\AsignaturasSeeder;
-use Database\Seeders\DocentesSeeder;
-use Database\Seeders\RolesSeeder;
-use App\Models\ModuloEstudiante\Estudiante;
-use App\Models\ModuloSecretaria\Carrera;
-use App\Models\ModuloSecretaria\Facultad;
-use App\Models\ModuloSeguridad\Role;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder

--- a/app/Infraestructure/Persistence/seeders/DocentesSeeder.php
+++ b/app/Infraestructure/Persistence/seeders/DocentesSeeder.php
@@ -2,11 +2,11 @@
 
 namespace Database\Seeders;
 
+use App\Domain\Catalogo\Entities\Carrera;
+use App\Domain\Docente\Entities\Docente;
+use App\Domain\Seguridad\Entities\Role;
+use App\Domain\Usuarios\Entities\User;
 use Illuminate\Database\Seeder;
-use App\Models\ModuloSecretaria\Docente;
-use App\Models\User;
-use App\Models\ModuloSecretaria\Carrera;
-use App\Models\ModuloSeguridad\Role;
 use Illuminate\Support\Facades\Hash;
 
 class DocentesSeeder extends Seeder
@@ -31,7 +31,7 @@ class DocentesSeeder extends Seeder
             $user = User::create([
                 'name' => $docente['name'],
                 'email' => $docente['email'],
-                'password' => 'secret',
+                'password' => Hash::make('secret'),
                 'role_id' => $role?->id,
                 'email_verified_at' => now(),
             ]);

--- a/app/Infraestructure/Persistence/seeders/FacultadesSeeder.php
+++ b/app/Infraestructure/Persistence/seeders/FacultadesSeeder.php
@@ -2,9 +2,9 @@
 
 namespace Database\Seeders;
 
+use App\Domain\Catalogo\Entities\Carrera;
+use App\Domain\Catalogo\Entities\Facultad;
 use Illuminate\Database\Seeder;
-use App\Models\ModuloSecretaria\Facultad;
-use App\Models\ModuloSecretaria\Carrera;
 
 class FacultadesSeeder extends Seeder
 {

--- a/app/Infraestructure/Persistence/seeders/RolesSeeder.php
+++ b/app/Infraestructure/Persistence/seeders/RolesSeeder.php
@@ -2,8 +2,8 @@
 
 namespace Database\Seeders;
 
+use App\Domain\Seguridad\Entities\Role;
 use Illuminate\Database\Seeder;
-use App\Models\ModuloSeguridad\Role;
 
 class RolesSeeder extends Seeder
 {

--- a/app/Infraestructure/Persistence/seeders/tipoConstanciaSeeder.php
+++ b/app/Infraestructure/Persistence/seeders/tipoConstanciaSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use App\Models\ModuloSecretaria\TipoConstancia;
+use App\Domain\Catalogo\Entities\TipoConstancia;
 use Illuminate\Database\Seeder;
 
 class TipoConstanciaSeeder extends Seeder

--- a/app/Jobs/SendAppealStatusMail.php
+++ b/app/Jobs/SendAppealStatusMail.php
@@ -4,7 +4,7 @@ namespace App\Jobs;
 
 use App\Mail\AppealApprovalMail;
 use App\Mail\AppealRejectionMail;
-use App\Models\ModuloEstudiante\Apelacion;
+use App\Domain\Apelaciones\Entities\Apelacion;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;

--- a/app/Jobs/SendStatusMail.php
+++ b/app/Jobs/SendStatusMail.php
@@ -2,9 +2,9 @@
 
 namespace App\Jobs;
 
+use App\Domain\Solicitud\Entities\Solicitud;
 use App\Mail\ApprovalMail;
 use App\Mail\RejectionMail;
-use App\Models\ModuloEstudiante\Solicitud;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;

--- a/app/Presentation/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Presentation/Http/Controllers/Auth/NewPasswordController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Auth;
 
+use App\Domain\Usuarios\Entities\User;
 use App\Http\Controllers\Controller;
-use App\Models\User;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;

--- a/app/Presentation/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Presentation/Http/Controllers/Auth/RegisteredUserController.php
@@ -2,8 +2,11 @@
 
 namespace App\Http\Controllers\Auth;
 
+use App\Domain\Estudiante\Entities\Estudiante;
+use App\Domain\Seguridad\Entities\Role;
+use App\Domain\Shared\ValueObjects\EmailInstitucional;
+use App\Domain\Usuarios\Entities\User;
 use App\Http\Controllers\Controller;
-use App\Models\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -12,9 +15,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\View\View;
-use App\Models\ModuloSeguridad\Role;
-use App\Models\ModuloSecretaria\Carrera;
-use App\Models\ModuloEstudiante\Estudiante;
+use App\Domain\Catalogo\Entities\Carrera;
 
 class RegisteredUserController extends Controller
 {
@@ -64,10 +65,11 @@ class RegisteredUserController extends Controller
         }
         
         $estudianteRole = Role::where('name', 'estudiante')->first();
+        $correoInstitucional = (string) new EmailInstitucional($request->email);
 
         $user = User::create([
             'name' => $request->name,
-            'email' => $request->email,
+            'email' => $correoInstitucional,
             'password' => Hash::make($request->password),
             'role_id' => $estudianteRole?->id,
         ]);

--- a/app/Presentation/Http/Controllers/Auth/TeacherEmailVerificationOnLoginTest.php
+++ b/app/Presentation/Http/Controllers/Auth/TeacherEmailVerificationOnLoginTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature\Auth;
 
-use App\Models\User;
-use App\Models\ModuloSeguridad\Role;
+use App\Domain\Usuarios\Entities\User;
+use App\Domain\Seguridad\Entities\Role;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Auth\Notifications\VerifyEmail;

--- a/app/Presentation/Http/Controllers/Docentes/ReprogramacionController.php
+++ b/app/Presentation/Http/Controllers/Docentes/ReprogramacionController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\ModuloDocente;
 
 use App\Application\Reprogramaciones\ReprogramacionService;
 use App\Http\Controllers\Controller;
-use App\Models\ModuloEstudiante\Solicitud;
+use App\Domain\Solicitud\Entities\Solicitud;
 use Illuminate\Http\Request;
 
 class ReprogramacionController extends Controller

--- a/app/Presentation/Http/Controllers/Estudiante/ApelacionController.php
+++ b/app/Presentation/Http/Controllers/Estudiante/ApelacionController.php
@@ -5,8 +5,8 @@ namespace App\Http\Controllers\ModuloEstudiante;
 use App\Application\Apelaciones\ApelacionService;
 use App\Enums\EstadoApelacion;
 use App\Http\Controllers\Controller;
-use App\Models\ModuloEstudiante\Apelacion;
-use App\Models\ModuloEstudiante\Solicitud;
+use App\Domain\Apelaciones\Entities\Apelacion;
+use App\Domain\Solicitud\Entities\Solicitud;
 use Illuminate\Http\Request;
 
 class ApelacionController extends Controller

--- a/app/Presentation/Http/Controllers/Estudiante/EstudianteController.php
+++ b/app/Presentation/Http/Controllers/Estudiante/EstudianteController.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 
 // Models
-use App\Models\ModuloEstudiante\Estudiante;
+use App\Domain\Estudiante\Entities\Estudiante;
 
 class EstudianteController extends Controller
 {

--- a/app/Presentation/Http/Controllers/Estudiante/SolicitudController.php
+++ b/app/Presentation/Http/Controllers/Estudiante/SolicitudController.php
@@ -6,8 +6,8 @@ use App\Application\Catalogo\CatalogoService;
 use App\Application\Solicitudes\SolicitudService;
 use App\Enums\EstadoSolicitud;
 use App\Http\Controllers\Controller;
-use App\Models\ModuloEstudiante\Solicitud;
-use App\Models\ModuloSecretaria\Facultad;
+use App\Domain\Catalogo\Entities\Facultad;
+use App\Domain\Solicitud\Entities\Solicitud;
 use Illuminate\Http\Request;
 
 class SolicitudController extends Controller

--- a/app/Presentation/Http/Controllers/Secretaria/ApelacionController.php
+++ b/app/Presentation/Http/Controllers/Secretaria/ApelacionController.php
@@ -8,7 +8,7 @@ use App\Enums\EstadoApelacion;
 use App\Enums\EstadoSolicitud;
 use App\Http\Controllers\Controller;
 use App\Jobs\SendAppealStatusMail;
-use App\Models\ModuloEstudiante\Apelacion;
+use App\Domain\Apelaciones\Entities\Apelacion;
 use Illuminate\Http\Request;
 
 class ApelacionController extends Controller

--- a/app/Presentation/Http/Controllers/Secretaria/AsignaturaController.php
+++ b/app/Presentation/Http/Controllers/Secretaria/AsignaturaController.php
@@ -7,10 +7,10 @@ use Illuminate\Http\Request;
 use Illuminate\Database\QueryException;
 
 // Models
-use App\Models\ModuloSecretaria\Asignatura;
+use App\Domain\Catalogo\Entities\Asignatura;
+use App\Domain\Catalogo\Entities\Facultad;
 use App\Imports\AsignaturasImport;
 use Maatwebsite\Excel\Facades\Excel;
-use App\Models\ModuloSecretaria\Facultad;
 
 class AsignaturaController extends Controller
 {

--- a/app/Presentation/Http/Controllers/Secretaria/CarreraController.php
+++ b/app/Presentation/Http/Controllers/Secretaria/CarreraController.php
@@ -7,8 +7,8 @@ use Illuminate\Http\Request;
 use Illuminate\Database\QueryException;
 
 // Models
-use App\Models\ModuloSecretaria\Carrera;
-use App\Models\ModuloSecretaria\Facultad;
+use App\Domain\Catalogo\Entities\Carrera;
+use App\Domain\Catalogo\Entities\Facultad;
 
 class CarreraController extends Controller
 {

--- a/app/Presentation/Http/Controllers/Secretaria/DocenteController.php
+++ b/app/Presentation/Http/Controllers/Secretaria/DocenteController.php
@@ -7,13 +7,14 @@ use Illuminate\Http\Request;
 use Illuminate\Database\QueryException;
 
 // Models
-use App\Models\ModuloSecretaria\Docente;
+use App\Domain\Docente\Entities\Docente;
+use App\Domain\Seguridad\Entities\Role;
+use App\Domain\Usuarios\Entities\User;
 use App\Imports\DocentesImport;
-use Maatwebsite\Excel\Facades\Excel;
-use App\Models\User;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
-use App\Models\ModuloSeguridad\Role;
+use Maatwebsite\Excel\Facades\Excel;
 
 class DocenteController extends Controller
 {

--- a/app/Presentation/Http/Controllers/Secretaria/FacultadController.php
+++ b/app/Presentation/Http/Controllers/Secretaria/FacultadController.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Database\QueryException;
 
 // Models
-use App\Models\ModuloSecretaria\Facultad;
+use App\Domain\Catalogo\Entities\Facultad;
 
 class FacultadController extends Controller
 {

--- a/app/Presentation/Http/Controllers/Secretaria/SolicitudController.php
+++ b/app/Presentation/Http/Controllers/Secretaria/SolicitudController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\ModuloSecretaria;
 use App\Application\Solicitudes\SolicitudService;
 use App\Enums\EstadoSolicitud;
 use App\Http\Controllers\Controller;
-use App\Models\ModuloEstudiante\Solicitud;
+use App\Domain\Solicitud\Entities\Solicitud;
 use Illuminate\Http\Request;
 
 class SolicitudController extends Controller

--- a/app/Presentation/Http/Controllers/Secretaria/TipoConstanciaController.php
+++ b/app/Presentation/Http/Controllers/Secretaria/TipoConstanciaController.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Database\QueryException;
 
 // Models
-use App\Models\ModuloSecretaria\TipoConstancia;
+use App\Domain\Catalogo\Entities\TipoConstancia;
 
 class TipoConstanciaController extends Controller
 {

--- a/app/Presentation/Http/Requests/Auth/LoginRequest.php
+++ b/app/Presentation/Http/Requests/Auth/LoginRequest.php
@@ -47,7 +47,7 @@ class LoginRequest extends FormRequest
         if (filter_var($login, FILTER_VALIDATE_EMAIL)) {
             $credentials['email'] = $login;
         } else {
-            $user = \App\Models\User::whereHas('estudiante', function ($q) use ($login) {
+            $user = \App\Domain\Usuarios\Entities\User::whereHas('estudiante', function ($q) use ($login) {
                 $q->where('cif', $login);
             })->first();
 

--- a/app/Presentation/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Presentation/Http/Requests/ProfileUpdateRequest.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Requests;
 
-use App\Models\User;
+use App\Domain\Shared\ValueObjects\EmailInstitucional;
+use App\Domain\Usuarios\Entities\User;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
 
 class ProfileUpdateRequest extends FormRequest
 {
@@ -26,5 +28,16 @@ class ProfileUpdateRequest extends FormRequest
                 Rule::unique(User::class)->ignore($this->user()->id),
             ],
         ];
+    }
+
+    protected function passedValidation(): void
+    {
+        try {
+            new EmailInstitucional($this->string('email'));
+        } catch (\InvalidArgumentException $exception) {
+            throw ValidationException::withMessages([
+                'email' => $exception->getMessage(),
+            ]);
+        }
     }
 }

--- a/config/auth.php
+++ b/config/auth.php
@@ -62,7 +62,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => env('AUTH_MODEL', App\Models\User::class),
+            'model' => env('AUTH_MODEL', App\Domain\Usuarios\Entities\User::class),
         ],
 
         // 'users' => [

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Domain\Usuarios\Entities\User>
  */
 class UserFactory extends Factory
 {

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth;
 
-use App\Models\User;
+use App\Domain\Usuarios\Entities\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth;
 
-use App\Models\User;
+use App\Domain\Usuarios\Entities\User;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;

--- a/tests/Feature/Auth/PasswordConfirmationTest.php
+++ b/tests/Feature/Auth/PasswordConfirmationTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth;
 
-use App\Models\User;
+use App\Domain\Usuarios\Entities\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth;
 
-use App\Models\User;
+use App\Domain\Usuarios\Entities\User;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;

--- a/tests/Feature/Auth/PasswordUpdateTest.php
+++ b/tests/Feature/Auth/PasswordUpdateTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth;
 
-use App\Models\User;
+use App\Domain\Usuarios\Entities\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Tests\TestCase;

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature;
 
-use App\Models\User;
+use App\Domain\Usuarios\Entities\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 


### PR DESCRIPTION
## Summary
- migrate domain entities to the App\\Domain namespace and provide aliases for legacy model references
- update repository interfaces and Eloquent implementations to type-hint domain entities and return neutral iterables
- introduce reusable value objects for institutional email and constancy files, applying them across services, controllers, and validation rules
- align application services, HTTP controllers, configuration, factories, and tests with the new domain entities

## Testing
- `composer test` *(fails: vendor autoloader missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_69053eff200c832e8820682e0ef0dd6e