### PR TITLE
Introduce DTO-driven commands and queries

### DIFF
--- a/app/Application/Apelaciones/Commands/ActualizarApelacionCommand.php
+++ b/app/Application/Apelaciones/Commands/ActualizarApelacionCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Application\Apelaciones\Commands;
+
+use App\Application\Apelaciones\DTOs\ActualizarApelacionDTO;
+use App\Domain\Shared\Enums\EstadoApelacion;
+
+final class ActualizarApelacionCommand
+{
+    public function __construct(private readonly ActualizarApelacionDTO $payload)
+    {
+    }
+
+    public function apelacionId(): int
+    {
+        return $this->payload->apelacionId();
+    }
+
+    public function estado(): ?EstadoApelacion
+    {
+        return $this->payload->estado();
+    }
+
+    public function respuesta(): ?string
+    {
+        return $this->payload->respuesta();
+    }
+
+    public function observacion(): ?string
+    {
+        return $this->payload->observacion();
+    }
+}

--- a/app/Application/Apelaciones/Commands/CrearApelacionCommand.php
+++ b/app/Application/Apelaciones/Commands/CrearApelacionCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Application\Apelaciones\Commands;
+
+use App\Application\Apelaciones\DTOs\CrearApelacionDTO;
+
+final class CrearApelacionCommand
+{
+    public function __construct(private readonly CrearApelacionDTO $payload)
+    {
+    }
+
+    public function observacion(): string
+    {
+        return $this->payload->observacion();
+    }
+
+    public function solicitudId(): int
+    {
+        return $this->payload->solicitudId();
+    }
+
+    public function apelacionPadreId(): ?int
+    {
+        return $this->payload->apelacionPadreId();
+    }
+}

--- a/app/Application/Apelaciones/DTOs/ActualizarApelacionDTO.php
+++ b/app/Application/Apelaciones/DTOs/ActualizarApelacionDTO.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Application\Apelaciones\DTOs;
+
+use App\Domain\Shared\Enums\EstadoApelacion;
+
+final class ActualizarApelacionDTO
+{
+    public function __construct(
+        private readonly int $apelacionId,
+        private readonly ?EstadoApelacion $estado,
+        private readonly ?string $respuesta,
+        private readonly ?string $observacion
+    ) {
+    }
+
+    public function apelacionId(): int
+    {
+        return $this->apelacionId;
+    }
+
+    public function estado(): ?EstadoApelacion
+    {
+        return $this->estado;
+    }
+
+    public function respuesta(): ?string
+    {
+        return $this->respuesta;
+    }
+
+    public function observacion(): ?string
+    {
+        return $this->observacion;
+    }
+}

--- a/app/Application/Apelaciones/DTOs/ApelacionIdDTO.php
+++ b/app/Application/Apelaciones/DTOs/ApelacionIdDTO.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Application\Apelaciones\DTOs;
+
+final class ApelacionIdDTO
+{
+    public function __construct(private readonly int $apelacionId)
+    {
+    }
+
+    public function apelacionId(): int
+    {
+        return $this->apelacionId;
+    }
+}

--- a/app/Application/Apelaciones/DTOs/ApelacionPorSolicitudDTO.php
+++ b/app/Application/Apelaciones/DTOs/ApelacionPorSolicitudDTO.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Application\Apelaciones\DTOs;
+
+final class ApelacionPorSolicitudDTO
+{
+    public function __construct(private readonly int $solicitudId)
+    {
+    }
+
+    public function solicitudId(): int
+    {
+        return $this->solicitudId;
+    }
+}

--- a/app/Application/Apelaciones/DTOs/ApelacionesPorEstudianteDTO.php
+++ b/app/Application/Apelaciones/DTOs/ApelacionesPorEstudianteDTO.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Application\Apelaciones\DTOs;
+
+final class ApelacionesPorEstudianteDTO
+{
+    public function __construct(private readonly int $estudianteId)
+    {
+    }
+
+    public function estudianteId(): int
+    {
+        return $this->estudianteId;
+    }
+}

--- a/app/Application/Apelaciones/DTOs/CrearApelacionDTO.php
+++ b/app/Application/Apelaciones/DTOs/CrearApelacionDTO.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Application\Apelaciones\DTOs;
+
+final class CrearApelacionDTO
+{
+    public function __construct(
+        private readonly string $observacion,
+        private readonly int $solicitudId,
+        private readonly ?int $apelacionPadreId
+    ) {
+    }
+
+    public function observacion(): string
+    {
+        return $this->observacion;
+    }
+
+    public function solicitudId(): int
+    {
+        return $this->solicitudId;
+    }
+
+    public function apelacionPadreId(): ?int
+    {
+        return $this->apelacionPadreId;
+    }
+}

--- a/app/Application/Apelaciones/DTOs/PaginarApelacionesPorEstadoDTO.php
+++ b/app/Application/Apelaciones/DTOs/PaginarApelacionesPorEstadoDTO.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Application\Apelaciones\DTOs;
+
+use App\Domain\Shared\Enums\EstadoApelacion;
+
+final class PaginarApelacionesPorEstadoDTO
+{
+    public function __construct(
+        private readonly EstadoApelacion $estado,
+        private readonly int $perPage
+    ) {
+    }
+
+    public function estado(): EstadoApelacion
+    {
+        return $this->estado;
+    }
+
+    public function perPage(): int
+    {
+        return $this->perPage;
+    }
+}

--- a/app/Application/Apelaciones/Handlers/ApelacionService.php
+++ b/app/Application/Apelaciones/Handlers/ApelacionService.php
@@ -2,11 +2,17 @@
 
 namespace App\Application\Apelaciones\Handlers;
 
+use App\Application\Apelaciones\Commands\ActualizarApelacionCommand;
+use App\Application\Apelaciones\Commands\CrearApelacionCommand;
+use App\Application\Apelaciones\Queries\ListarApelacionesPorEstudianteQuery;
+use App\Application\Apelaciones\Queries\ObtenerApelacionPorIdQuery;
+use App\Application\Apelaciones\Queries\ObtenerUltimaApelacionDeSolicitudQuery;
+use App\Application\Apelaciones\Queries\ObtenerUltimaApelacionRechazadaQuery;
+use App\Application\Apelaciones\Queries\PaginarApelacionesPorEstadoQuery;
 use App\Domain\Apelaciones\Entities\Apelacion as ApelacionEntity;
 use App\Domain\Apelaciones\Repositories\ApelacionRepository;
 use App\Domain\Shared\Enums\EstadoApelacion;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
-use Illuminate\Support\Collection;
 use InvalidArgumentException;
 
 class ApelacionService
@@ -16,32 +22,32 @@ class ApelacionService
     }
 
     /** @return iterable<Apelacion> */
-    public function listarFinalesPorEstudiante(int $estudianteId): iterable
+    public function listarFinalesPorEstudiante(ListarApelacionesPorEstudianteQuery $query): iterable
     {
-        return $this->apelaciones->listarFinalesPorEstudiante($estudianteId);
+        return $this->apelaciones->listarFinalesPorEstudiante($query->estudianteId());
     }
 
-    public function obtenerUltimaDeSolicitud(int $solicitudId): ?ApelacionEntity
+    public function obtenerUltimaDeSolicitud(ObtenerUltimaApelacionDeSolicitudQuery $query): ?ApelacionEntity
     {
-        return $this->apelaciones->obtenerUltimaPorSolicitud($solicitudId);
+        return $this->apelaciones->obtenerUltimaPorSolicitud($query->solicitudId());
     }
 
-    public function obtenerUltimaRechazada(int $solicitudId): ?ApelacionEntity
+    public function obtenerUltimaRechazada(ObtenerUltimaApelacionRechazadaQuery $query): ?ApelacionEntity
     {
-        return $this->apelaciones->obtenerUltimaRechazada($solicitudId);
+        return $this->apelaciones->obtenerUltimaRechazada($query->solicitudId());
     }
 
-    public function obtenerPorId(int $id): ApelacionEntity
+    public function obtenerPorId(ObtenerApelacionPorIdQuery $query): ApelacionEntity
     {
-        return $this->apelaciones->findById($id);
+        return $this->apelaciones->findById($query->apelacionId());
     }
 
-    public function crear(array $data): ApelacionEntity
+    public function crear(CrearApelacionCommand $command): ApelacionEntity
     {
-        $observacion = $this->requireTexto($data['observacion'] ?? null);
-        $solicitudId = $this->requireInt($data, 'solicitud_id');
-        $apelacionPadreId = isset($data['apelacion_id']) && $data['apelacion_id'] !== null
-            ? $this->requireInt($data, 'apelacion_id')
+        $observacion = $this->requireTexto($command->observacion());
+        $solicitudId = $this->requireInt($command->solicitudId(), 'solicitud_id');
+        $apelacionPadreId = $command->apelacionPadreId() !== null
+            ? $this->requireInt($command->apelacionPadreId(), 'apelacion_id')
             : null;
 
         $entity = ApelacionEntity::crear($observacion, $solicitudId, $apelacionPadreId);
@@ -49,41 +55,37 @@ class ApelacionService
         return $this->apelaciones->crear($entity);
     }
 
-    public function actualizar(ApelacionEntity $apelacion, array $data): ApelacionEntity
+    public function actualizar(ActualizarApelacionCommand $command): ApelacionEntity
     {
-        $estado = $data['estado'] ?? $apelacion->estado();
-        if (! $estado instanceof EstadoApelacion) {
-            $estado = EstadoApelacion::from($estado);
-        }
+        $apelacion = $this->apelaciones->findById($command->apelacionId());
+        $estado = $command->estado() ?? $apelacion->estado();
 
         if ($estado === EstadoApelacion::Pendiente) {
             $apelacion->dejarPendiente();
         } else {
-            $respuesta = $this->requireTexto($data['respuesta'] ?? null);
+            $respuesta = $this->requireTexto($command->respuesta());
             $apelacion->registrarRespuesta($respuesta, $estado);
         }
 
         return $this->apelaciones->actualizar($apelacion);
     }
 
-    public function paginarPorEstado(EstadoApelacion $estado, int $perPage = 9): LengthAwarePaginator
+    public function paginarPorEstado(PaginarApelacionesPorEstadoQuery $query): LengthAwarePaginator
     {
-        return $this->apelaciones->paginarPorEstado($estado, $perPage);
+        return $this->apelaciones->paginarPorEstado($query->estado(), $query->perPage());
     }
 
-    private function requireInt(array $data, string $key): int
+    private function requireInt(?int $valor, string $key): int
     {
-        $valor = $data[$key] ?? null;
-
         if ($valor === null) {
             throw new InvalidArgumentException(sprintf('El campo %s es obligatorio.', $key));
         }
 
-        if (! is_numeric($valor)) {
-            throw new InvalidArgumentException(sprintf('El campo %s debe ser numérico.', $key));
+        if ($valor <= 0) {
+            throw new InvalidArgumentException(sprintf('El campo %s debe ser un entero positivo.', $key));
         }
 
-        return (int) $valor;
+        return $valor;
     }
 
     private function requireTexto(?string $texto): string

--- a/app/Application/Apelaciones/Queries/ListarApelacionesPorEstudianteQuery.php
+++ b/app/Application/Apelaciones/Queries/ListarApelacionesPorEstudianteQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Application\Apelaciones\Queries;
+
+use App\Application\Apelaciones\DTOs\ApelacionesPorEstudianteDTO;
+
+final class ListarApelacionesPorEstudianteQuery
+{
+    public function __construct(private readonly ApelacionesPorEstudianteDTO $payload)
+    {
+    }
+
+    public function estudianteId(): int
+    {
+        return $this->payload->estudianteId();
+    }
+}

--- a/app/Application/Apelaciones/Queries/ObtenerApelacionPorIdQuery.php
+++ b/app/Application/Apelaciones/Queries/ObtenerApelacionPorIdQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Application\Apelaciones\Queries;
+
+use App\Application\Apelaciones\DTOs\ApelacionIdDTO;
+
+final class ObtenerApelacionPorIdQuery
+{
+    public function __construct(private readonly ApelacionIdDTO $payload)
+    {
+    }
+
+    public function apelacionId(): int
+    {
+        return $this->payload->apelacionId();
+    }
+}

--- a/app/Application/Apelaciones/Queries/ObtenerUltimaApelacionDeSolicitudQuery.php
+++ b/app/Application/Apelaciones/Queries/ObtenerUltimaApelacionDeSolicitudQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Application\Apelaciones\Queries;
+
+use App\Application\Apelaciones\DTOs\ApelacionPorSolicitudDTO;
+
+final class ObtenerUltimaApelacionDeSolicitudQuery
+{
+    public function __construct(private readonly ApelacionPorSolicitudDTO $payload)
+    {
+    }
+
+    public function solicitudId(): int
+    {
+        return $this->payload->solicitudId();
+    }
+}

--- a/app/Application/Apelaciones/Queries/ObtenerUltimaApelacionRechazadaQuery.php
+++ b/app/Application/Apelaciones/Queries/ObtenerUltimaApelacionRechazadaQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Application\Apelaciones\Queries;
+
+use App\Application\Apelaciones\DTOs\ApelacionPorSolicitudDTO;
+
+final class ObtenerUltimaApelacionRechazadaQuery
+{
+    public function __construct(private readonly ApelacionPorSolicitudDTO $payload)
+    {
+    }
+
+    public function solicitudId(): int
+    {
+        return $this->payload->solicitudId();
+    }
+}

--- a/app/Application/Apelaciones/Queries/PaginarApelacionesPorEstadoQuery.php
+++ b/app/Application/Apelaciones/Queries/PaginarApelacionesPorEstadoQuery.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Application\Apelaciones\Queries;
+
+use App\Application\Apelaciones\DTOs\PaginarApelacionesPorEstadoDTO;
+use App\Domain\Shared\Enums\EstadoApelacion;
+
+final class PaginarApelacionesPorEstadoQuery
+{
+    public function __construct(private readonly PaginarApelacionesPorEstadoDTO $payload)
+    {
+    }
+
+    public function estado(): EstadoApelacion
+    {
+        return $this->payload->estado();
+    }
+
+    public function perPage(): int
+    {
+        return $this->payload->perPage();
+    }
+}

--- a/app/Application/Catalogo/DTOs/AsignaturasPorFacultadDTO.php
+++ b/app/Application/Catalogo/DTOs/AsignaturasPorFacultadDTO.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Application\Catalogo\DTOs;
+
+final class AsignaturasPorFacultadDTO
+{
+    public function __construct(private readonly int $facultadId)
+    {
+    }
+
+    public function facultadId(): int
+    {
+        return $this->facultadId;
+    }
+}

--- a/app/Application/Catalogo/DTOs/BuscarAsignaturasDTO.php
+++ b/app/Application/Catalogo/DTOs/BuscarAsignaturasDTO.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Application\Catalogo\DTOs;
+
+final class BuscarAsignaturasDTO
+{
+    public function __construct(
+        private readonly string $termino,
+        private readonly ?int $facultadId,
+        private readonly int $limit
+    ) {
+    }
+
+    public function termino(): string
+    {
+        return $this->termino;
+    }
+
+    public function facultadId(): ?int
+    {
+        return $this->facultadId;
+    }
+
+    public function limit(): int
+    {
+        return $this->limit;
+    }
+}

--- a/app/Application/Catalogo/DTOs/BuscarDocentesDTO.php
+++ b/app/Application/Catalogo/DTOs/BuscarDocentesDTO.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Application\Catalogo\DTOs;
+
+final class BuscarDocentesDTO
+{
+    public function __construct(
+        private readonly string $termino,
+        private readonly int $limit
+    ) {
+    }
+
+    public function termino(): string
+    {
+        return $this->termino;
+    }
+
+    public function limit(): int
+    {
+        return $this->limit;
+    }
+}

--- a/app/Application/Catalogo/Handlers/CatalogoService.php
+++ b/app/Application/Catalogo/Handlers/CatalogoService.php
@@ -2,6 +2,12 @@
 
 namespace App\Application\Catalogo\Handlers;
 
+use App\Application\Catalogo\Queries\BuscarAsignaturasQuery;
+use App\Application\Catalogo\Queries\BuscarDocentesQuery;
+use App\Application\Catalogo\Queries\ListarAsignaturasPorFacultadQuery;
+use App\Application\Catalogo\Queries\ListarDocentesQuery;
+use App\Application\Catalogo\Queries\ListarFacultadesQuery;
+use App\Application\Catalogo\Queries\ListarTiposConstanciaQuery;
 use App\Domain\Catalogo\Repositories\AsignaturaRepository;
 use App\Domain\Catalogo\Repositories\FacultadRepository;
 use App\Domain\Catalogo\Repositories\TipoConstanciaRepository;
@@ -18,38 +24,38 @@ class CatalogoService
     }
 
     /** @return iterable<\App\Domain\Docente\Entities\Docente> */
-    public function docentes(): iterable
+    public function docentes(ListarDocentesQuery $query): iterable
     {
         return $this->docentes->allWithUsuario();
     }
 
     /** @return iterable<\App\Domain\Catalogo\Entities\Facultad> */
-    public function facultades(): iterable
+    public function facultades(ListarFacultadesQuery $query): iterable
     {
         return $this->facultades->allOrdered();
     }
 
     /** @return iterable<\App\Domain\Catalogo\Entities\TipoConstancia> */
-    public function tiposConstancia(): iterable
+    public function tiposConstancia(ListarTiposConstanciaQuery $query): iterable
     {
         return $this->tiposConstancia->all();
     }
 
     /** @return iterable<\App\Domain\Catalogo\Entities\Asignatura> */
-    public function asignaturasPorFacultad(int $facultadId): iterable
+    public function asignaturasPorFacultad(ListarAsignaturasPorFacultadQuery $query): iterable
     {
-        return $this->asignaturas->listByFacultad($facultadId);
+        return $this->asignaturas->listByFacultad($query->facultadId());
     }
 
     /** @return iterable<\App\Domain\Docente\Entities\Docente> */
-    public function buscarDocentes(string $nombre, int $limit = 10): iterable
+    public function buscarDocentes(BuscarDocentesQuery $query): iterable
     {
-        return $this->docentes->searchByNombre($nombre, $limit);
+        return $this->docentes->searchByNombre($query->termino(), $query->limit());
     }
 
     /** @return iterable<\App\Domain\Catalogo\Entities\Asignatura> */
-    public function buscarAsignaturas(string $termino = '', ?int $facultadId = null, int $limit = 10): iterable
+    public function buscarAsignaturas(BuscarAsignaturasQuery $query): iterable
     {
-        return $this->asignaturas->search($termino, $facultadId, $limit);
+        return $this->asignaturas->search($query->termino(), $query->facultadId(), $query->limit());
     }
 }

--- a/app/Application/Catalogo/Queries/BuscarAsignaturasQuery.php
+++ b/app/Application/Catalogo/Queries/BuscarAsignaturasQuery.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Application\Catalogo\Queries;
+
+use App\Application\Catalogo\DTOs\BuscarAsignaturasDTO;
+
+final class BuscarAsignaturasQuery
+{
+    public function __construct(private readonly BuscarAsignaturasDTO $payload)
+    {
+    }
+
+    public function termino(): string
+    {
+        return $this->payload->termino();
+    }
+
+    public function facultadId(): ?int
+    {
+        return $this->payload->facultadId();
+    }
+
+    public function limit(): int
+    {
+        return $this->payload->limit();
+    }
+}

--- a/app/Application/Catalogo/Queries/BuscarDocentesQuery.php
+++ b/app/Application/Catalogo/Queries/BuscarDocentesQuery.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Application\Catalogo\Queries;
+
+use App\Application\Catalogo\DTOs\BuscarDocentesDTO;
+
+final class BuscarDocentesQuery
+{
+    public function __construct(private readonly BuscarDocentesDTO $payload)
+    {
+    }
+
+    public function termino(): string
+    {
+        return $this->payload->termino();
+    }
+
+    public function limit(): int
+    {
+        return $this->payload->limit();
+    }
+}

--- a/app/Application/Catalogo/Queries/ListarAsignaturasPorFacultadQuery.php
+++ b/app/Application/Catalogo/Queries/ListarAsignaturasPorFacultadQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Application\Catalogo\Queries;
+
+use App\Application\Catalogo\DTOs\AsignaturasPorFacultadDTO;
+
+final class ListarAsignaturasPorFacultadQuery
+{
+    public function __construct(private readonly AsignaturasPorFacultadDTO $payload)
+    {
+    }
+
+    public function facultadId(): int
+    {
+        return $this->payload->facultadId();
+    }
+}

--- a/app/Application/Catalogo/Queries/ListarDocentesQuery.php
+++ b/app/Application/Catalogo/Queries/ListarDocentesQuery.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Application\Catalogo\Queries;
+
+final class ListarDocentesQuery
+{
+}

--- a/app/Application/Catalogo/Queries/ListarFacultadesQuery.php
+++ b/app/Application/Catalogo/Queries/ListarFacultadesQuery.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Application\Catalogo\Queries;
+
+final class ListarFacultadesQuery
+{
+}

--- a/app/Application/Catalogo/Queries/ListarTiposConstanciaQuery.php
+++ b/app/Application/Catalogo/Queries/ListarTiposConstanciaQuery.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Application\Catalogo\Queries;
+
+final class ListarTiposConstanciaQuery
+{
+}

--- a/app/Application/Reprogramaciones/Commands/ActualizarReprogramacionCommand.php
+++ b/app/Application/Reprogramaciones/Commands/ActualizarReprogramacionCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Application\Reprogramaciones\Commands;
+
+use App\Application\Reprogramaciones\DTOs\ActualizarReprogramacionDTO;
+use App\Domain\Shared\Enums\EstadoAsistencia;
+
+final class ActualizarReprogramacionCommand
+{
+    public function __construct(private readonly ActualizarReprogramacionDTO $payload)
+    {
+    }
+
+    public function reprogramacionId(): int
+    {
+        return $this->payload->reprogramacionId();
+    }
+
+    public function fecha(): ?string
+    {
+        return $this->payload->fecha();
+    }
+
+    public function hora(): ?string
+    {
+        return $this->payload->hora();
+    }
+
+    public function observaciones(): ?string
+    {
+        return $this->payload->observaciones();
+    }
+
+    public function asistencia(): ?EstadoAsistencia
+    {
+        return $this->payload->asistencia();
+    }
+}

--- a/app/Application/Reprogramaciones/Commands/CrearReprogramacionCommand.php
+++ b/app/Application/Reprogramaciones/Commands/CrearReprogramacionCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Application\Reprogramaciones\Commands;
+
+use App\Application\Reprogramaciones\DTOs\CrearReprogramacionDTO;
+
+final class CrearReprogramacionCommand
+{
+    public function __construct(private readonly CrearReprogramacionDTO $payload)
+    {
+    }
+
+    public function solicitudId(): int
+    {
+        return $this->payload->solicitudId();
+    }
+
+    public function fecha(): string
+    {
+        return $this->payload->fecha();
+    }
+
+    public function hora(): string
+    {
+        return $this->payload->hora();
+    }
+
+    public function observaciones(): ?string
+    {
+        return $this->payload->observaciones();
+    }
+}

--- a/app/Application/Reprogramaciones/DTOs/ActualizarReprogramacionDTO.php
+++ b/app/Application/Reprogramaciones/DTOs/ActualizarReprogramacionDTO.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Application\Reprogramaciones\DTOs;
+
+use App\Domain\Shared\Enums\EstadoAsistencia;
+
+final class ActualizarReprogramacionDTO
+{
+    public function __construct(
+        private readonly int $reprogramacionId,
+        private readonly ?string $fecha,
+        private readonly ?string $hora,
+        private readonly ?string $observaciones,
+        private readonly ?EstadoAsistencia $asistencia
+    ) {
+    }
+
+    public function reprogramacionId(): int
+    {
+        return $this->reprogramacionId;
+    }
+
+    public function fecha(): ?string
+    {
+        return $this->fecha;
+    }
+
+    public function hora(): ?string
+    {
+        return $this->hora;
+    }
+
+    public function observaciones(): ?string
+    {
+        return $this->observaciones;
+    }
+
+    public function asistencia(): ?EstadoAsistencia
+    {
+        return $this->asistencia;
+    }
+}

--- a/app/Application/Reprogramaciones/DTOs/CrearReprogramacionDTO.php
+++ b/app/Application/Reprogramaciones/DTOs/CrearReprogramacionDTO.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Application\Reprogramaciones\DTOs;
+
+final class CrearReprogramacionDTO
+{
+    public function __construct(
+        private readonly int $solicitudId,
+        private readonly string $fecha,
+        private readonly string $hora,
+        private readonly ?string $observaciones
+    ) {
+    }
+
+    public function solicitudId(): int
+    {
+        return $this->solicitudId;
+    }
+
+    public function fecha(): string
+    {
+        return $this->fecha;
+    }
+
+    public function hora(): string
+    {
+        return $this->hora;
+    }
+
+    public function observaciones(): ?string
+    {
+        return $this->observaciones;
+    }
+}

--- a/app/Application/Reprogramaciones/DTOs/DocenteIdDTO.php
+++ b/app/Application/Reprogramaciones/DTOs/DocenteIdDTO.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Application\Reprogramaciones\DTOs;
+
+final class DocenteIdDTO
+{
+    public function __construct(private readonly int $docenteId)
+    {
+    }
+
+    public function docenteId(): int
+    {
+        return $this->docenteId;
+    }
+}

--- a/app/Application/Reprogramaciones/DTOs/ReprogramacionIdDTO.php
+++ b/app/Application/Reprogramaciones/DTOs/ReprogramacionIdDTO.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Application\Reprogramaciones\DTOs;
+
+final class ReprogramacionIdDTO
+{
+    public function __construct(private readonly int $reprogramacionId)
+    {
+    }
+
+    public function reprogramacionId(): int
+    {
+        return $this->reprogramacionId;
+    }
+}

--- a/app/Application/Reprogramaciones/Handlers/ReprogramacionService.php
+++ b/app/Application/Reprogramaciones/Handlers/ReprogramacionService.php
@@ -2,7 +2,17 @@
 
 namespace App\Application\Reprogramaciones\Handlers;
 
+use App\Application\Reprogramaciones\Commands\ActualizarReprogramacionCommand;
+use App\Application\Reprogramaciones\Commands\CrearReprogramacionCommand;
+use App\Application\Reprogramaciones\Queries\ObtenerReprogramacionPorIdQuery;
+use App\Application\Reprogramaciones\Queries\ReprogramacionesPorDocenteQuery;
+use App\Application\Reprogramaciones\Queries\SolicitudesAprobadasSinReprogramarQuery;
+use App\Application\Solicitudes\DTOs\SolicitudIdDTO;
+use App\Application\Solicitudes\DTOs\SolicitudesDocenteDTO;
 use App\Application\Solicitudes\Handlers\SolicitudService;
+use App\Application\Solicitudes\Queries\ObtenerSolicitudPorIdQuery;
+use App\Application\Solicitudes\Queries\ReprogramacionesPorDocenteQuery as SolicitudesReprogramacionesPorDocenteQuery;
+use App\Application\Solicitudes\Queries\SolicitudesAprobadasSinReprogramarQuery as SolicitudesSolicitudesAprobadasSinReprogramarQuery;
 use App\Domain\Reprogramacion\Entities\Reprogramacion as ReprogramacionEntity;
 use App\Domain\Reprogramacion\Repositories\ReprogramacionRepository;
 use App\Domain\Solicitud\Entities\Solicitud as SolicitudEntity;
@@ -21,25 +31,29 @@ class ReprogramacionService
     ) {
     }
 
-    public function obtenerPorId(int $id): ReprogramacionEntity
+    public function obtenerPorId(ObtenerReprogramacionPorIdQuery $query): ReprogramacionEntity
     {
-        return $this->reprogramaciones->findById($id);
+        return $this->reprogramaciones->findById($query->reprogramacionId());
     }
 
-    public function obtenerSolicitudPorId(int $id): SolicitudEntity
+    public function obtenerSolicitudPorId(ObtenerSolicitudPorIdQuery $query): SolicitudEntity
     {
-        return $this->solicitudes->obtenerPorId($id);
+        return $this->solicitudes->obtenerPorId($query);
     }
 
-    public function crear(SolicitudEntity $solicitud, array $data): ReprogramacionEntity
+    public function crear(CrearReprogramacionCommand $command): ReprogramacionEntity
     {
-        $fecha = $this->parseFecha($data['fecha'] ?? null);
-        $hora = $this->requireHora($data['hora'] ?? null);
+        $solicitud = $this->solicitudes->obtenerPorId(
+            new ObtenerSolicitudPorIdQuery(new SolicitudIdDTO($command->solicitudId()))
+        );
+
+        $fecha = $this->parseFecha($command->fecha());
+        $hora = $this->requireHora($command->hora());
 
         $entity = ReprogramacionEntity::crear(
             $fecha,
             $hora,
-            $data['observaciones'] ?? null,
+            $command->observaciones(),
             $solicitud->id()?->value() ?? throw new InvalidArgumentException('La solicitud debe existir para reprogramar.')
         );
 
@@ -62,33 +76,36 @@ class ReprogramacionService
         return $reprogramacion;
     }
 
-    public function actualizar(ReprogramacionEntity $reprogramacion, array $data): ReprogramacionEntity
+    public function actualizar(ActualizarReprogramacionCommand $command): ReprogramacionEntity
     {
-        if (array_key_exists('fecha', $data) || array_key_exists('hora', $data) || array_key_exists('observaciones', $data)) {
-            $fecha = $this->parseFecha($data['fecha'] ?? $reprogramacion->fecha()->format('Y-m-d'));
-            $hora = $this->requireHora($data['hora'] ?? $reprogramacion->hora()->value());
-            $observaciones = $data['observaciones'] ?? $reprogramacion->observaciones()?->value();
+        $reprogramacion = $this->reprogramaciones->findById($command->reprogramacionId());
+
+        if ($command->fecha() !== null || $command->hora() !== null || $command->observaciones() !== null) {
+            $fecha = $this->parseFecha($command->fecha() ?? $reprogramacion->fecha()->format('Y-m-d'));
+            $hora = $this->requireHora($command->hora() ?? $reprogramacion->hora()->value());
+            $observaciones = $command->observaciones() ?? $reprogramacion->observaciones()?->value();
             $reprogramacion->reprogramar($fecha, $hora, $observaciones);
         }
 
-        if (array_key_exists('asistencia', $data) && $data['asistencia'] !== null) {
-            $estado = $data['asistencia'] instanceof EstadoAsistencia
-                ? $data['asistencia']
-                : EstadoAsistencia::from($data['asistencia']);
-            $reprogramacion->registrarAsistencia($estado);
+        if ($command->asistencia() !== null) {
+            $reprogramacion->registrarAsistencia($command->asistencia());
         }
 
         return $this->reprogramaciones->update($reprogramacion);
     }
 
-    public function solicitudesAprobadasSinReprogramar(int $docenteId)
+    public function solicitudesAprobadasSinReprogramar(SolicitudesAprobadasSinReprogramarQuery $query)
     {
-        return $this->solicitudes->solicitudesAprobadasSinReprogramar($docenteId);
+        return $this->solicitudes->solicitudesAprobadasSinReprogramar(
+            new SolicitudesSolicitudesAprobadasSinReprogramarQuery(new SolicitudesDocenteDTO($query->docenteId()))
+        );
     }
 
-    public function reprogramacionesPorDocente(int $docenteId)
+    public function reprogramacionesPorDocente(ReprogramacionesPorDocenteQuery $query)
     {
-        return $this->solicitudes->reprogramacionesPorDocente($docenteId);
+        return $this->solicitudes->reprogramacionesPorDocente(
+            new SolicitudesReprogramacionesPorDocenteQuery(new SolicitudesDocenteDTO($query->docenteId()))
+        );
     }
 
     private function parseFecha(?string $fecha): DateTimeImmutable

--- a/app/Application/Reprogramaciones/Queries/ObtenerReprogramacionPorIdQuery.php
+++ b/app/Application/Reprogramaciones/Queries/ObtenerReprogramacionPorIdQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Application\Reprogramaciones\Queries;
+
+use App\Application\Reprogramaciones\DTOs\ReprogramacionIdDTO;
+
+final class ObtenerReprogramacionPorIdQuery
+{
+    public function __construct(private readonly ReprogramacionIdDTO $payload)
+    {
+    }
+
+    public function reprogramacionId(): int
+    {
+        return $this->payload->reprogramacionId();
+    }
+}

--- a/app/Application/Reprogramaciones/Queries/ReprogramacionesPorDocenteQuery.php
+++ b/app/Application/Reprogramaciones/Queries/ReprogramacionesPorDocenteQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Application\Reprogramaciones\Queries;
+
+use App\Application\Reprogramaciones\DTOs\DocenteIdDTO;
+
+final class ReprogramacionesPorDocenteQuery
+{
+    public function __construct(private readonly DocenteIdDTO $payload)
+    {
+    }
+
+    public function docenteId(): int
+    {
+        return $this->payload->docenteId();
+    }
+}

--- a/app/Application/Reprogramaciones/Queries/SolicitudesAprobadasSinReprogramarQuery.php
+++ b/app/Application/Reprogramaciones/Queries/SolicitudesAprobadasSinReprogramarQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Application\Reprogramaciones\Queries;
+
+use App\Application\Reprogramaciones\DTOs\DocenteIdDTO;
+
+final class SolicitudesAprobadasSinReprogramarQuery
+{
+    public function __construct(private readonly DocenteIdDTO $payload)
+    {
+    }
+
+    public function docenteId(): int
+    {
+        return $this->payload->docenteId();
+    }
+}

--- a/app/Application/Solicitudes/Commands/ActualizarEstadoSolicitudCommand.php
+++ b/app/Application/Solicitudes/Commands/ActualizarEstadoSolicitudCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Application\Solicitudes\Commands;
+
+use App\Application\Solicitudes\DTOs\ActualizarEstadoSolicitudDTO;
+use App\Domain\Shared\Enums\EstadoSolicitud;
+
+final class ActualizarEstadoSolicitudCommand
+{
+    public function __construct(private readonly ActualizarEstadoSolicitudDTO $payload)
+    {
+    }
+
+    public function solicitudId(): int
+    {
+        return $this->payload->solicitudId();
+    }
+
+    public function estado(): EstadoSolicitud
+    {
+        return $this->payload->estado();
+    }
+
+    public function respuesta(): ?string
+    {
+        return $this->payload->respuesta();
+    }
+}

--- a/app/Application/Solicitudes/Commands/ActualizarSolicitudCommand.php
+++ b/app/Application/Solicitudes/Commands/ActualizarSolicitudCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Application\Solicitudes\Commands;
+
+use App\Application\Solicitudes\DTOs\ActualizarSolicitudDTO;
+use Illuminate\Http\UploadedFile;
+
+final class ActualizarSolicitudCommand
+{
+    public function __construct(private readonly ActualizarSolicitudDTO $payload)
+    {
+    }
+
+    public function solicitudId(): int
+    {
+        return $this->payload->solicitudId();
+    }
+
+    public function fechaAusencia(): string
+    {
+        return $this->payload->fechaAusencia();
+    }
+
+    public function docenteId(): int
+    {
+        return $this->payload->docenteId();
+    }
+
+    public function asignaturaId(): int
+    {
+        return $this->payload->asignaturaId();
+    }
+
+    public function tipoConstanciaId(): int
+    {
+        return $this->payload->tipoConstanciaId();
+    }
+
+    public function observaciones(): ?string
+    {
+        return $this->payload->observaciones();
+    }
+
+    public function constancia(): ?UploadedFile
+    {
+        return $this->payload->constancia();
+    }
+
+    public function eliminarConstancia(): bool
+    {
+        return $this->payload->eliminarConstancia();
+    }
+}

--- a/app/Application/Solicitudes/Commands/CrearSolicitudCommand.php
+++ b/app/Application/Solicitudes/Commands/CrearSolicitudCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Application\Solicitudes\Commands;
+
+use App\Application\Solicitudes\DTOs\CrearSolicitudDTO;
+use Illuminate\Http\UploadedFile;
+
+final class CrearSolicitudCommand
+{
+    public function __construct(private readonly CrearSolicitudDTO $payload)
+    {
+    }
+
+    public function fechaAusencia(): string
+    {
+        return $this->payload->fechaAusencia();
+    }
+
+    public function docenteId(): int
+    {
+        return $this->payload->docenteId();
+    }
+
+    public function asignaturaId(): int
+    {
+        return $this->payload->asignaturaId();
+    }
+
+    public function tipoConstanciaId(): int
+    {
+        return $this->payload->tipoConstanciaId();
+    }
+
+    public function observaciones(): ?string
+    {
+        return $this->payload->observaciones();
+    }
+
+    public function constancia(): ?UploadedFile
+    {
+        return $this->payload->constancia();
+    }
+
+    public function estudianteId(): int
+    {
+        return $this->payload->estudianteId();
+    }
+}

--- a/app/Application/Solicitudes/Commands/EliminarSolicitudCommand.php
+++ b/app/Application/Solicitudes/Commands/EliminarSolicitudCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Application\Solicitudes\Commands;
+
+use App\Application\Solicitudes\DTOs\SolicitudIdDTO;
+
+final class EliminarSolicitudCommand
+{
+    public function __construct(private readonly SolicitudIdDTO $payload)
+    {
+    }
+
+    public function solicitudId(): int
+    {
+        return $this->payload->solicitudId();
+    }
+}

--- a/app/Application/Solicitudes/DTOs/ActualizarEstadoSolicitudDTO.php
+++ b/app/Application/Solicitudes/DTOs/ActualizarEstadoSolicitudDTO.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Application\Solicitudes\DTOs;
+
+use App\Domain\Shared\Enums\EstadoSolicitud;
+
+final class ActualizarEstadoSolicitudDTO
+{
+    public function __construct(
+        private readonly int $solicitudId,
+        private readonly EstadoSolicitud $estado,
+        private readonly ?string $respuesta
+    ) {
+    }
+
+    public function solicitudId(): int
+    {
+        return $this->solicitudId;
+    }
+
+    public function estado(): EstadoSolicitud
+    {
+        return $this->estado;
+    }
+
+    public function respuesta(): ?string
+    {
+        return $this->respuesta;
+    }
+}

--- a/app/Application/Solicitudes/DTOs/ActualizarSolicitudDTO.php
+++ b/app/Application/Solicitudes/DTOs/ActualizarSolicitudDTO.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Application\Solicitudes\DTOs;
+
+use Illuminate\Http\UploadedFile;
+
+final class ActualizarSolicitudDTO
+{
+    public function __construct(
+        private readonly int $solicitudId,
+        private readonly string $fechaAusencia,
+        private readonly int $docenteId,
+        private readonly int $asignaturaId,
+        private readonly int $tipoConstanciaId,
+        private readonly ?string $observaciones,
+        private readonly ?UploadedFile $constancia,
+        private readonly bool $eliminarConstancia
+    ) {
+    }
+
+    public function solicitudId(): int
+    {
+        return $this->solicitudId;
+    }
+
+    public function fechaAusencia(): string
+    {
+        return $this->fechaAusencia;
+    }
+
+    public function docenteId(): int
+    {
+        return $this->docenteId;
+    }
+
+    public function asignaturaId(): int
+    {
+        return $this->asignaturaId;
+    }
+
+    public function tipoConstanciaId(): int
+    {
+        return $this->tipoConstanciaId;
+    }
+
+    public function observaciones(): ?string
+    {
+        return $this->observaciones;
+    }
+
+    public function constancia(): ?UploadedFile
+    {
+        return $this->constancia;
+    }
+
+    public function eliminarConstancia(): bool
+    {
+        return $this->eliminarConstancia;
+    }
+}

--- a/app/Application/Solicitudes/DTOs/CrearSolicitudDTO.php
+++ b/app/Application/Solicitudes/DTOs/CrearSolicitudDTO.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Application\Solicitudes\DTOs;
+
+use Illuminate\Http\UploadedFile;
+
+final class CrearSolicitudDTO
+{
+    public function __construct(
+        private readonly string $fechaAusencia,
+        private readonly int $docenteId,
+        private readonly int $asignaturaId,
+        private readonly int $tipoConstanciaId,
+        private readonly ?string $observaciones,
+        private readonly ?UploadedFile $constancia,
+        private readonly int $estudianteId
+    ) {
+    }
+
+    public function fechaAusencia(): string
+    {
+        return $this->fechaAusencia;
+    }
+
+    public function docenteId(): int
+    {
+        return $this->docenteId;
+    }
+
+    public function asignaturaId(): int
+    {
+        return $this->asignaturaId;
+    }
+
+    public function tipoConstanciaId(): int
+    {
+        return $this->tipoConstanciaId;
+    }
+
+    public function observaciones(): ?string
+    {
+        return $this->observaciones;
+    }
+
+    public function constancia(): ?UploadedFile
+    {
+        return $this->constancia;
+    }
+
+    public function estudianteId(): int
+    {
+        return $this->estudianteId;
+    }
+}

--- a/app/Application/Solicitudes/DTOs/PaginarSolicitudesEstudianteDTO.php
+++ b/app/Application/Solicitudes/DTOs/PaginarSolicitudesEstudianteDTO.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Application\Solicitudes\DTOs;
+
+use App\Domain\Shared\Enums\EstadoSolicitud;
+
+final class PaginarSolicitudesEstudianteDTO
+{
+    public function __construct(
+        private readonly int $estudianteId,
+        private readonly EstadoSolicitud $estado,
+        private readonly int $perPage
+    ) {
+    }
+
+    public function estudianteId(): int
+    {
+        return $this->estudianteId;
+    }
+
+    public function estado(): EstadoSolicitud
+    {
+        return $this->estado;
+    }
+
+    public function perPage(): int
+    {
+        return $this->perPage;
+    }
+}

--- a/app/Application/Solicitudes/DTOs/PaginarSolicitudesSecretariaDTO.php
+++ b/app/Application/Solicitudes/DTOs/PaginarSolicitudesSecretariaDTO.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Application\Solicitudes\DTOs;
+
+use App\Domain\Shared\Enums\EstadoSolicitud;
+
+final class PaginarSolicitudesSecretariaDTO
+{
+    public function __construct(
+        private readonly EstadoSolicitud $estado,
+        private readonly bool $sinApelacionesPendientes,
+        private readonly int $perPage
+    ) {
+    }
+
+    public function estado(): EstadoSolicitud
+    {
+        return $this->estado;
+    }
+
+    public function sinApelacionesPendientes(): bool
+    {
+        return $this->sinApelacionesPendientes;
+    }
+
+    public function perPage(): int
+    {
+        return $this->perPage;
+    }
+}

--- a/app/Application/Solicitudes/DTOs/SolicitudIdDTO.php
+++ b/app/Application/Solicitudes/DTOs/SolicitudIdDTO.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Application\Solicitudes\DTOs;
+
+final class SolicitudIdDTO
+{
+    public function __construct(private readonly int $solicitudId)
+    {
+    }
+
+    public function solicitudId(): int
+    {
+        return $this->solicitudId;
+    }
+}

--- a/app/Application/Solicitudes/DTOs/SolicitudesDocenteDTO.php
+++ b/app/Application/Solicitudes/DTOs/SolicitudesDocenteDTO.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Application\Solicitudes\DTOs;
+
+final class SolicitudesDocenteDTO
+{
+    public function __construct(private readonly int $docenteId)
+    {
+    }
+
+    public function docenteId(): int
+    {
+        return $this->docenteId;
+    }
+}

--- a/app/Application/Solicitudes/Handlers/SolicitudService.php
+++ b/app/Application/Solicitudes/Handlers/SolicitudService.php
@@ -2,6 +2,15 @@
 
 namespace App\Application\Solicitudes\Handlers;
 
+use App\Application\Solicitudes\Commands\ActualizarEstadoSolicitudCommand;
+use App\Application\Solicitudes\Commands\ActualizarSolicitudCommand;
+use App\Application\Solicitudes\Commands\CrearSolicitudCommand;
+use App\Application\Solicitudes\Commands\EliminarSolicitudCommand;
+use App\Application\Solicitudes\Queries\ObtenerSolicitudPorIdQuery;
+use App\Application\Solicitudes\Queries\PaginarSolicitudesEstudianteQuery;
+use App\Application\Solicitudes\Queries\PaginarSolicitudesSecretariaQuery;
+use App\Application\Solicitudes\Queries\ReprogramacionesPorDocenteQuery;
+use App\Application\Solicitudes\Queries\SolicitudesAprobadasSinReprogramarQuery;
 use App\Domain\Shared\ValueObjects\ArchivoConstancia;
 use App\Domain\Solicitud\Entities\Solicitud as SolicitudEntity;
 use App\Domain\Solicitud\Repositories\SolicitudRepository;
@@ -12,7 +21,6 @@ use App\Models\ModuloEstudiante\Solicitud as SolicitudModel;
 use DateTimeImmutable;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
-use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Mail;
 use InvalidArgumentException;
 
@@ -24,29 +32,38 @@ class SolicitudService
     ) {
     }
 
-    public function paginateForEstudiante(int $estudianteId, EstadoSolicitud $estado, int $perPage = 9): LengthAwarePaginator
+    public function paginateForEstudiante(PaginarSolicitudesEstudianteQuery $query): LengthAwarePaginator
     {
-        return $this->solicitudes->paginateByEstadoForEstudiante($estudianteId, $estado, $perPage);
+        return $this->solicitudes->paginateByEstadoForEstudiante(
+            $query->estudianteId(),
+            $query->estado(),
+            $query->perPage()
+        );
     }
 
-    public function paginateForSecretaria(EstadoSolicitud $estado, bool $sinApelacionesPendientes, int $perPage = 9): LengthAwarePaginator
+    public function paginateForSecretaria(PaginarSolicitudesSecretariaQuery $query): LengthAwarePaginator
     {
-        return $this->solicitudes->paginateByEstadoForSecretaria($estado, $sinApelacionesPendientes, $perPage);
+        return $this->solicitudes->paginateByEstadoForSecretaria(
+            $query->estado(),
+            $query->sinApelacionesPendientes(),
+            $query->perPage()
+        );
     }
 
-    public function obtenerPorId(int $id): SolicitudEntity
+    public function obtenerPorId(ObtenerSolicitudPorIdQuery $query): SolicitudEntity
     {
-        return $this->solicitudes->findById($id);
+        return $this->solicitudes->findById($query->solicitudId());
     }
 
-    public function crear(array $data, ?UploadedFile $constancia, int $estudianteId): SolicitudEntity
+    public function crear(CrearSolicitudCommand $command): SolicitudEntity
     {
-        $fechaAusencia = $this->parseFecha($data['fecha_ausencia'] ?? null);
-        $docenteId = $this->requireInt($data, 'docente_id');
-        $asignaturaId = $this->requireInt($data, 'asignatura_id');
-        $tipoConstanciaId = $this->requireInt($data, 'tipo_constancia_id');
+        $fechaAusencia = $this->parseFecha($command->fechaAusencia());
+        $docenteId = $this->requirePositiveInt($command->docenteId(), 'docente_id');
+        $asignaturaId = $this->requirePositiveInt($command->asignaturaId(), 'asignatura_id');
+        $tipoConstanciaId = $this->requirePositiveInt($command->tipoConstanciaId(), 'tipo_constancia_id');
 
         $rutaConstancia = null;
+        $constancia = $command->constancia();
         if ($constancia) {
             $rutaConstancia = $this->publicStorage->putFile('constancias', $constancia);
         }
@@ -54,8 +71,8 @@ class SolicitudService
         $entity = SolicitudEntity::crearNueva(
             $fechaAusencia,
             $rutaConstancia ? ArchivoConstancia::fromPath($rutaConstancia) : null,
-            $data['observaciones'] ?? '',
-            $estudianteId,
+            $command->observaciones() ?? '',
+            $this->requirePositiveInt($command->estudianteId(), 'estudiante_id'),
             $docenteId,
             $asignaturaId,
             $tipoConstanciaId
@@ -64,32 +81,31 @@ class SolicitudService
         return $this->solicitudes->create($entity);
     }
 
-    public function actualizar(
-        SolicitudEntity $solicitud,
-        array $data,
-        ?UploadedFile $constancia = null,
-        bool $eliminarConstancia = false
-    ): SolicitudEntity {
-        $fechaAusencia = $this->parseFecha($data['fecha_ausencia'] ?? $solicitud->fechaAusencia()->format('Y-m-d'));
-        $docenteId = $this->requireInt($data, 'docente_id', $solicitud->docenteId()->value());
-        $asignaturaId = $this->requireInt($data, 'asignatura_id', $solicitud->asignaturaId()->value());
-        $tipoConstanciaId = $this->requireInt($data, 'tipo_constancia_id', $solicitud->tipoConstanciaId()->value());
+    public function actualizar(ActualizarSolicitudCommand $command): SolicitudEntity
+    {
+        $solicitud = $this->solicitudes->findById($command->solicitudId());
+
+        $fechaAusencia = $this->parseFecha($command->fechaAusencia());
+        $docenteId = $this->requirePositiveInt($command->docenteId(), 'docente_id');
+        $asignaturaId = $this->requirePositiveInt($command->asignaturaId(), 'asignatura_id');
+        $tipoConstanciaId = $this->requirePositiveInt($command->tipoConstanciaId(), 'tipo_constancia_id');
 
         $solicitud->actualizarDatos(
             $fechaAusencia,
-            $data['observaciones'] ?? $solicitud->observaciones()->value(),
+            $command->observaciones() ?? $solicitud->observaciones()->value(),
             $docenteId,
             $asignaturaId,
             $tipoConstanciaId
         );
 
         $constanciaAnterior = $solicitud->constancia();
+        $constancia = $command->constancia();
 
         if ($constancia) {
             $rutaConstancia = $this->publicStorage->putFile('constancias', $constancia);
             $solicitud->adjuntarConstancia(ArchivoConstancia::fromPath($rutaConstancia));
             $this->eliminarConstanciaPath($constanciaAnterior?->path());
-        } elseif ($eliminarConstancia) {
+        } elseif ($command->eliminarConstancia()) {
             $solicitud->eliminarConstancia();
             $this->eliminarConstanciaPath($constanciaAnterior?->path());
         }
@@ -97,15 +113,19 @@ class SolicitudService
         return $this->solicitudes->update($solicitud);
     }
 
-    public function eliminar(SolicitudEntity $solicitud): void
+    public function eliminar(EliminarSolicitudCommand $command): void
     {
+        $solicitud = $this->solicitudes->findById($command->solicitudId());
+
         $this->eliminarConstanciaPath($solicitud->constancia()?->path());
         $this->solicitudes->delete($solicitud);
     }
 
-    public function actualizarEstado(SolicitudEntity $solicitud, EstadoSolicitud $estado, ?string $respuesta): SolicitudEntity
+    public function actualizarEstado(ActualizarEstadoSolicitudCommand $command): SolicitudEntity
     {
-        $solicitud->actualizarEstado($estado, $respuesta);
+        $solicitud = $this->solicitudes->findById($command->solicitudId());
+
+        $solicitud->actualizarEstado($command->estado(), $command->respuesta());
 
         $solicitudActualizada = $this->solicitudes->update($solicitud);
 
@@ -115,15 +135,15 @@ class SolicitudService
     }
 
     /** @return iterable<Solicitud> */
-    public function solicitudesAprobadasSinReprogramar(int $docenteId)
+    public function solicitudesAprobadasSinReprogramar(SolicitudesAprobadasSinReprogramarQuery $query)
     {
-        return $this->solicitudes->solicitudesAprobadasSinReprogramacion($docenteId);
+        return $this->solicitudes->solicitudesAprobadasSinReprogramacion($query->docenteId());
     }
 
     /** @return iterable<Solicitud> */
-    public function reprogramacionesPorDocente(int $docenteId)
+    public function reprogramacionesPorDocente(ReprogramacionesPorDocenteQuery $query)
     {
-        return $this->solicitudes->reprogramacionesPorDocente($docenteId);
+        return $this->solicitudes->reprogramacionesPorDocente($query->docenteId());
     }
 
     private function eliminarConstanciaPath(?string $path): void
@@ -169,33 +189,12 @@ class SolicitudService
         return $instancia;
     }
 
-    private function requireInt(array $data, string $key, ?int $default = null): int
+    private function requirePositiveInt(int $valor, string $key): int
     {
-        $valor = $data[$key] ?? $default;
-
-        if ($valor === null) {
-            throw new InvalidArgumentException(sprintf('El campo %s es obligatorio.', $key));
-        }
-
-        if (! is_numeric($valor)) {
-            throw new InvalidArgumentException(sprintf('El campo %s debe ser numérico.', $key));
-        }
-
-        $intValor = (int) $valor;
-
-        if ($intValor <= 0) {
+        if ($valor <= 0) {
             throw new InvalidArgumentException(sprintf('El campo %s debe ser un entero positivo.', $key));
         }
 
-        return $intValor;
-    }
-
-    private function fechaString(mixed $valor): string
-    {
-        if ($valor instanceof \DateTimeInterface) {
-            return $valor->format('Y-m-d');
-        }
-
-        return (string) $valor;
+        return $valor;
     }
 }

--- a/app/Application/Solicitudes/Queries/ObtenerSolicitudPorIdQuery.php
+++ b/app/Application/Solicitudes/Queries/ObtenerSolicitudPorIdQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Application\Solicitudes\Queries;
+
+use App\Application\Solicitudes\DTOs\SolicitudIdDTO;
+
+final class ObtenerSolicitudPorIdQuery
+{
+    public function __construct(private readonly SolicitudIdDTO $payload)
+    {
+    }
+
+    public function solicitudId(): int
+    {
+        return $this->payload->solicitudId();
+    }
+}

--- a/app/Application/Solicitudes/Queries/PaginarSolicitudesEstudianteQuery.php
+++ b/app/Application/Solicitudes/Queries/PaginarSolicitudesEstudianteQuery.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Application\Solicitudes\Queries;
+
+use App\Application\Solicitudes\DTOs\PaginarSolicitudesEstudianteDTO;
+use App\Domain\Shared\Enums\EstadoSolicitud;
+
+final class PaginarSolicitudesEstudianteQuery
+{
+    public function __construct(private readonly PaginarSolicitudesEstudianteDTO $payload)
+    {
+    }
+
+    public function estudianteId(): int
+    {
+        return $this->payload->estudianteId();
+    }
+
+    public function estado(): EstadoSolicitud
+    {
+        return $this->payload->estado();
+    }
+
+    public function perPage(): int
+    {
+        return $this->payload->perPage();
+    }
+}

--- a/app/Application/Solicitudes/Queries/PaginarSolicitudesSecretariaQuery.php
+++ b/app/Application/Solicitudes/Queries/PaginarSolicitudesSecretariaQuery.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Application\Solicitudes\Queries;
+
+use App\Application\Solicitudes\DTOs\PaginarSolicitudesSecretariaDTO;
+use App\Domain\Shared\Enums\EstadoSolicitud;
+
+final class PaginarSolicitudesSecretariaQuery
+{
+    public function __construct(private readonly PaginarSolicitudesSecretariaDTO $payload)
+    {
+    }
+
+    public function estado(): EstadoSolicitud
+    {
+        return $this->payload->estado();
+    }
+
+    public function sinApelacionesPendientes(): bool
+    {
+        return $this->payload->sinApelacionesPendientes();
+    }
+
+    public function perPage(): int
+    {
+        return $this->payload->perPage();
+    }
+}

--- a/app/Application/Solicitudes/Queries/ReprogramacionesPorDocenteQuery.php
+++ b/app/Application/Solicitudes/Queries/ReprogramacionesPorDocenteQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Application\Solicitudes\Queries;
+
+use App\Application\Solicitudes\DTOs\SolicitudesDocenteDTO;
+
+final class ReprogramacionesPorDocenteQuery
+{
+    public function __construct(private readonly SolicitudesDocenteDTO $payload)
+    {
+    }
+
+    public function docenteId(): int
+    {
+        return $this->payload->docenteId();
+    }
+}

--- a/app/Application/Solicitudes/Queries/SolicitudesAprobadasSinReprogramarQuery.php
+++ b/app/Application/Solicitudes/Queries/SolicitudesAprobadasSinReprogramarQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Application\Solicitudes\Queries;
+
+use App\Application\Solicitudes\DTOs\SolicitudesDocenteDTO;
+
+final class SolicitudesAprobadasSinReprogramarQuery
+{
+    public function __construct(private readonly SolicitudesDocenteDTO $payload)
+    {
+    }
+
+    public function docenteId(): int
+    {
+        return $this->payload->docenteId();
+    }
+}

--- a/app/Presentation/Http/Controllers/Docentes/ReprogramacionController.php
+++ b/app/Presentation/Http/Controllers/Docentes/ReprogramacionController.php
@@ -2,10 +2,18 @@
 
 namespace App\Http\Controllers\ModuloDocente;
 
+use App\Application\Reprogramaciones\Commands\ActualizarReprogramacionCommand;
+use App\Application\Reprogramaciones\Commands\CrearReprogramacionCommand;
+use App\Application\Reprogramaciones\DTOs\ActualizarReprogramacionDTO;
+use App\Application\Reprogramaciones\DTOs\CrearReprogramacionDTO;
+use App\Application\Reprogramaciones\DTOs\DocenteIdDTO;
 use App\Application\Reprogramaciones\Handlers\ReprogramacionService;
+use App\Application\Reprogramaciones\Queries\ReprogramacionesPorDocenteQuery;
+use App\Application\Reprogramaciones\Queries\SolicitudesAprobadasSinReprogramarQuery;
 use App\Http\Controllers\Controller;
 use App\Domain\Solicitud\Entities\Solicitud;
 use Illuminate\Http\Request;
+use App\Domain\Shared\Enums\EstadoAsistencia;
 
 class ReprogramacionController extends Controller
 {
@@ -16,8 +24,12 @@ class ReprogramacionController extends Controller
     public function index(Request $request)
     {
         $docenteId = $request->user()->docente->id;
-        $solicitudesAReprogramar = $this->reprogramaciones->solicitudesAprobadasSinReprogramar($docenteId);
-        $reprogramaciones = $this->reprogramaciones->reprogramacionesPorDocente($docenteId);
+        $solicitudesAReprogramar = $this->reprogramaciones->solicitudesAprobadasSinReprogramar(
+            new SolicitudesAprobadasSinReprogramarQuery(new DocenteIdDTO($docenteId))
+        );
+        $reprogramaciones = $this->reprogramaciones->reprogramacionesPorDocente(
+            new ReprogramacionesPorDocenteQuery(new DocenteIdDTO($docenteId))
+        );
 
         return view('ModuloDocente.solicitudes.index', compact('solicitudesAReprogramar', 'reprogramaciones'));
     }
@@ -30,13 +42,16 @@ class ReprogramacionController extends Controller
 
     public function storeReprogramacion(Request $request, Solicitud $solicitud)
     {
-        $solicitudEntity = $this->reprogramaciones->obtenerSolicitudPorId($solicitud->id);
-
-        $this->reprogramaciones->crear($solicitudEntity, [
-            'fecha' => $request->input('fecha'),
-            'hora' => $request->input('hora'),
-            'observaciones' => $request->input('observaciones'),
-        ]);
+        $this->reprogramaciones->crear(
+            new CrearReprogramacionCommand(
+                new CrearReprogramacionDTO(
+                    $solicitud->id,
+                    (string) $request->input('fecha'),
+                    (string) $request->input('hora'),
+                    $request->input('observaciones')
+                )
+            )
+        );
 
         return redirect()
             ->route('docente.solicitudes.index')
@@ -45,17 +60,22 @@ class ReprogramacionController extends Controller
 
     public function updateReprogramacion(Request $request, Solicitud $solicitud)
     {
-        $reprogramacion = $solicitud->reprogramacion
-            ? $this->reprogramaciones->obtenerPorId($solicitud->reprogramacion->id)
-            : null;
+        if ($solicitud->reprogramacion) {
+            $asistencia = $request->filled('asistencia')
+                ? EstadoAsistencia::from($request->input('asistencia'))
+                : null;
 
-        if ($reprogramacion) {
-            $this->reprogramaciones->actualizar($reprogramacion, [
-                'fecha' => $request->input('fecha'),
-                'hora' => $request->input('hora'),
-                'asistencia' => $request->input('asistencia'),
-                'observaciones' => $request->input('observaciones'),
-            ]);
+            $this->reprogramaciones->actualizar(
+                new ActualizarReprogramacionCommand(
+                    new ActualizarReprogramacionDTO(
+                        $solicitud->reprogramacion->id,
+                        $request->input('fecha'),
+                        $request->input('hora'),
+                        $request->input('observaciones'),
+                        $asistencia
+                    )
+                )
+            );
         }
         return redirect()
             ->route('docente.solicitudes.index')

--- a/app/Presentation/Http/Controllers/Estudiante/ApelacionController.php
+++ b/app/Presentation/Http/Controllers/Estudiante/ApelacionController.php
@@ -2,7 +2,16 @@
 
 namespace App\Http\Controllers\ModuloEstudiante;
 
+use App\Application\Apelaciones\Commands\ActualizarApelacionCommand;
+use App\Application\Apelaciones\Commands\CrearApelacionCommand;
+use App\Application\Apelaciones\DTOs\ActualizarApelacionDTO;
+use App\Application\Apelaciones\DTOs\ApelacionesPorEstudianteDTO;
+use App\Application\Apelaciones\DTOs\ApelacionPorSolicitudDTO;
+use App\Application\Apelaciones\DTOs\CrearApelacionDTO;
 use App\Application\Apelaciones\Handlers\ApelacionService;
+use App\Application\Apelaciones\Queries\ListarApelacionesPorEstudianteQuery;
+use App\Application\Apelaciones\Queries\ObtenerUltimaApelacionDeSolicitudQuery;
+use App\Application\Apelaciones\Queries\ObtenerUltimaApelacionRechazadaQuery;
 use App\Domain\Shared\Enums\EstadoApelacion;
 use App\Http\Controllers\Controller;
 use App\Domain\Apelaciones\Entities\Apelacion;
@@ -19,7 +28,9 @@ class ApelacionController extends Controller
     {
         $estudianteId = auth()->user()->estudiante->id;
         $apelaciones = $this->apelaciones
-            ->listarFinalesPorEstudiante($estudianteId)
+            ->listarFinalesPorEstudiante(
+                new ListarApelacionesPorEstudianteQuery(new ApelacionesPorEstudianteDTO($estudianteId))
+            )
             ->groupBy(fn($a) => $a->estado->value);
 
         return view('ModuloEstudiante.apelaciones.index', [
@@ -32,7 +43,9 @@ class ApelacionController extends Controller
      */
     public function create(Solicitud $solicitud)
     {
-        $ultimaApelacion = $this->apelaciones->obtenerUltimaDeSolicitud($solicitud->id);
+        $ultimaApelacion = $this->apelaciones->obtenerUltimaDeSolicitud(
+            new ObtenerUltimaApelacionDeSolicitudQuery(new ApelacionPorSolicitudDTO($solicitud->id))
+        );
 
         $respuesta = $ultimaApelacion?->respuesta ?? $solicitud->respuesta;
 
@@ -43,17 +56,19 @@ class ApelacionController extends Controller
     {
         $observacion = $request->input('observacion_estudiante');
 
-        $ultimaRechazada = $this->apelaciones->obtenerUltimaRechazada($solicitud->id);
+        $ultimaRechazada = $this->apelaciones->obtenerUltimaRechazada(
+            new ObtenerUltimaApelacionRechazadaQuery(new ApelacionPorSolicitudDTO($solicitud->id))
+        );
 
-        $data = [
-            'observacion' => $observacion,
-            'estado' => EstadoApelacion::Pendiente,
-            'solicitud_id' => $solicitud->id,
-            'apelacion_id' => $ultimaRechazada?->id,
-            'respuesta' => null,
-        ];
-
-        $apelacion = $this->apelaciones->crear($data);
+        $apelacion = $this->apelaciones->crear(
+            new CrearApelacionCommand(
+                new CrearApelacionDTO(
+                    $observacion,
+                    $solicitud->id,
+                    $ultimaRechazada?->id
+                )
+            )
+        );
         
         $redirectEstado = $request->query('estado', 'rechazada');
     
@@ -94,9 +109,16 @@ class ApelacionController extends Controller
             abort(403);
         }
 
-        $this->apelaciones->actualizar($apelacion, [
-            'observacion' => $request->input('observacion_estudiante'),
-        ]);
+        $this->apelaciones->actualizar(
+            new ActualizarApelacionCommand(
+                new ActualizarApelacionDTO(
+                    $apelacion->id,
+                    null,
+                    null,
+                    $request->input('observacion_estudiante')
+                )
+            )
+        );
 
         return redirect()
             ->route('estudiante.apelaciones.index')

--- a/app/Presentation/Http/Controllers/Estudiante/SolicitudController.php
+++ b/app/Presentation/Http/Controllers/Estudiante/SolicitudController.php
@@ -2,8 +2,25 @@
 
 namespace App\Http\Controllers\ModuloEstudiante;
 
+use App\Application\Catalogo\DTOs\AsignaturasPorFacultadDTO;
+use App\Application\Catalogo\DTOs\BuscarAsignaturasDTO;
+use App\Application\Catalogo\DTOs\BuscarDocentesDTO;
 use App\Application\Catalogo\Handlers\CatalogoService;
+use App\Application\Catalogo\Queries\BuscarAsignaturasQuery;
+use App\Application\Catalogo\Queries\BuscarDocentesQuery;
+use App\Application\Catalogo\Queries\ListarAsignaturasPorFacultadQuery;
+use App\Application\Catalogo\Queries\ListarDocentesQuery;
+use App\Application\Catalogo\Queries\ListarFacultadesQuery;
+use App\Application\Catalogo\Queries\ListarTiposConstanciaQuery;
+use App\Application\Solicitudes\Commands\ActualizarSolicitudCommand;
+use App\Application\Solicitudes\Commands\CrearSolicitudCommand;
+use App\Application\Solicitudes\Commands\EliminarSolicitudCommand;
+use App\Application\Solicitudes\DTOs\ActualizarSolicitudDTO;
+use App\Application\Solicitudes\DTOs\CrearSolicitudDTO;
+use App\Application\Solicitudes\DTOs\PaginarSolicitudesEstudianteDTO;
+use App\Application\Solicitudes\DTOs\SolicitudIdDTO;
 use App\Application\Solicitudes\Handlers\SolicitudService;
+use App\Application\Solicitudes\Queries\PaginarSolicitudesEstudianteQuery;
 use App\Domain\Shared\Enums\EstadoSolicitud;
 use App\Http\Controllers\Controller;
 use App\Domain\Catalogo\Entities\Facultad;
@@ -23,9 +40,13 @@ class SolicitudController extends Controller
         $estado = EstadoSolicitud::tryFrom($request->query('estado')) ?? EstadoSolicitud::Pendiente;
 
         $solicitudes = $this->solicitudes->paginateForEstudiante(
-            $request->user()->estudiante->id,
-            $estado,
-            9
+            new PaginarSolicitudesEstudianteQuery(
+                new PaginarSolicitudesEstudianteDTO(
+                    $request->user()->estudiante->id,
+                    $estado,
+                    9
+                )
+            )
         );
 
         return view('ModuloEstudiante.solicitudes.index', [
@@ -39,9 +60,9 @@ class SolicitudController extends Controller
      */
     public function create()
     {
-        $docentes = $this->catalogo->docentes();
-        $facultades = $this->catalogo->facultades();
-        $TiposConstancia = $this->catalogo->tiposConstancia();
+        $docentes = $this->catalogo->docentes(new ListarDocentesQuery());
+        $facultades = $this->catalogo->facultades(new ListarFacultadesQuery());
+        $TiposConstancia = $this->catalogo->tiposConstancia(new ListarTiposConstanciaQuery());
 
         return view('ModuloEstudiante.solicitudes.create', [
             'docentes' => $docentes,
@@ -55,13 +76,19 @@ class SolicitudController extends Controller
      */
     public function store(Request $request)
     {
-        $data = $request->all();
-
-        $this->solicitudes->crear(
-            $data,
-            $request->hasFile('constancia') ? $request->file('constancia') : null,
-            $request->user()->estudiante->id
+        $command = new CrearSolicitudCommand(
+            new CrearSolicitudDTO(
+                (string) $request->input('fecha_ausencia'),
+                (int) $request->input('docente_id'),
+                (int) $request->input('asignatura_id'),
+                (int) $request->input('tipo_constancia_id'),
+                $request->input('observaciones'),
+                $request->hasFile('constancia') ? $request->file('constancia') : null,
+                $request->user()->estudiante->id
+            )
         );
+
+        $this->solicitudes->crear($command);
 
         $redirectEstado = $request->query('estado', 'pendiente');
 
@@ -87,9 +114,9 @@ class SolicitudController extends Controller
      */
     public function edit(Solicitud $solicitud)
     {
-        $docentes = $this->catalogo->docentes();
-        $facultades = $this->catalogo->facultades();
-        $TiposConstancia = $this->catalogo->tiposConstancia();
+        $docentes = $this->catalogo->docentes(new ListarDocentesQuery());
+        $facultades = $this->catalogo->facultades(new ListarFacultadesQuery());
+        $TiposConstancia = $this->catalogo->tiposConstancia(new ListarTiposConstanciaQuery());
 
         return view('ModuloEstudiante.solicitudes.edit', [
             'solicitud' => $solicitud,
@@ -104,16 +131,20 @@ class SolicitudController extends Controller
      */
     public function update(Request $request, Solicitud $solicitud)
     {
-        $data = $request->all();
-
-        $solicitudEntity = $this->solicitudes->obtenerPorId($solicitud->id);
-
-        $this->solicitudes->actualizar(
-            $solicitudEntity,
-            $data,
-            $request->hasFile('constancia') ? $request->file('constancia') : null,
-            $request->boolean('delete_constancia')
+        $command = new ActualizarSolicitudCommand(
+            new ActualizarSolicitudDTO(
+                $solicitud->id,
+                (string) $request->input('fecha_ausencia'),
+                (int) $request->input('docente_id'),
+                (int) $request->input('asignatura_id'),
+                (int) $request->input('tipo_constancia_id'),
+                $request->input('observaciones'),
+                $request->hasFile('constancia') ? $request->file('constancia') : null,
+                $request->boolean('delete_constancia')
+            )
         );
+
+        $this->solicitudes->actualizar($command);
 
         $redirectEstado = $request->query('estado', 'pendiente');
 
@@ -127,14 +158,20 @@ class SolicitudController extends Controller
      */
     public function asignaturasPorFacultad(Facultad $facultad)
     {
-        return response()->json($this->catalogo->asignaturasPorFacultad($facultad->id));
+        return response()->json(
+            $this->catalogo->asignaturasPorFacultad(
+                new ListarAsignaturasPorFacultadQuery(new AsignaturasPorFacultadDTO($facultad->id))
+            )
+        );
     }
 
     public function buscarDocentes(Request $request)
     {
         $query = $request->query('q');
         $docentes = $this->catalogo
-            ->buscarDocentes($query ?? '')
+            ->buscarDocentes(
+                new BuscarDocentesQuery(new BuscarDocentesDTO($query ?? '', 10))
+            )
             ->map(fn($d) => ['id' => $d->id, 'nombre' => $d->usuario->name]);
 
         return response()->json($docentes);
@@ -146,7 +183,11 @@ class SolicitudController extends Controller
         $facultadId = $request->query('facultad');
 
         $asignaturas = $this->catalogo
-            ->buscarAsignaturas($query ?? '', $facultadId)
+            ->buscarAsignaturas(
+                new BuscarAsignaturasQuery(
+                    new BuscarAsignaturasDTO($query ?? '', $facultadId ? (int) $facultadId : null, 10)
+                )
+            )
             ->map(fn($a) => ['id' => $a->id, 'nombre' => $a->nombre]);
 
         return response()->json($asignaturas);
@@ -157,9 +198,9 @@ class SolicitudController extends Controller
      */
     public function destroy(Request $request, Solicitud $solicitud)
     {
-        $solicitudEntity = $this->solicitudes->obtenerPorId($solicitud->id);
-
-        $this->solicitudes->eliminar($solicitudEntity);
+        $this->solicitudes->eliminar(
+            new EliminarSolicitudCommand(new SolicitudIdDTO($solicitud->id))
+        );
 
         $redirectEstado = $request->query('estado', 'pendiente');
 

--- a/app/Presentation/Http/Controllers/Secretaria/ApelacionController.php
+++ b/app/Presentation/Http/Controllers/Secretaria/ApelacionController.php
@@ -2,8 +2,16 @@
 
 namespace App\Http\Controllers\ModuloSecretaria;
 
+use App\Application\Apelaciones\Commands\ActualizarApelacionCommand;
+use App\Application\Apelaciones\DTOs\ActualizarApelacionDTO;
+use App\Application\Apelaciones\DTOs\PaginarApelacionesPorEstadoDTO;
 use App\Application\Apelaciones\Handlers\ApelacionService;
+use App\Application\Apelaciones\Queries\PaginarApelacionesPorEstadoQuery;
+use App\Application\Solicitudes\Commands\ActualizarEstadoSolicitudCommand;
+use App\Application\Solicitudes\DTOs\ActualizarEstadoSolicitudDTO;
+use App\Application\Solicitudes\DTOs\SolicitudIdDTO;
 use App\Application\Solicitudes\Handlers\SolicitudService;
+use App\Application\Solicitudes\Queries\ObtenerSolicitudPorIdQuery;
 use App\Domain\Shared\Enums\EstadoApelacion;
 use App\Domain\Shared\Enums\EstadoSolicitud;
 use App\Http\Controllers\Controller;
@@ -22,7 +30,9 @@ class ApelacionController extends Controller
     public function index(Request $request)
     {
         $estado = EstadoApelacion::tryFrom($request->query('estado')) ?? EstadoApelacion::Pendiente;
-        $apelaciones = $this->apelaciones->paginarPorEstado($estado, 9);
+        $apelaciones = $this->apelaciones->paginarPorEstado(
+            new PaginarApelacionesPorEstadoQuery(new PaginarApelacionesPorEstadoDTO($estado, 9))
+        );
 
         return view('ModuloSecretaria.apelaciones.index', [
             'apelaciones' => $apelaciones,
@@ -54,18 +64,23 @@ class ApelacionController extends Controller
         $estado = EstadoApelacion::from($request->input('estado'));
         $respuesta = $request->input('respuesta');
 
-        $apelacionEntity = $this->apelaciones->obtenerPorId($apelacion->id);
-
-        $this->apelaciones->actualizar($apelacionEntity, [
-            'estado' => $estado,
-            'respuesta' => $respuesta,
-        ]);
+        $this->apelaciones->actualizar(
+            new ActualizarApelacionCommand(
+                new ActualizarApelacionDTO($apelacion->id, $estado, $respuesta, null)
+            )
+        );
 
         $apelacion->refresh()->load('apelacionPadre', 'solicitud.estudiante.usuario');
 
         if ($estado === EstadoApelacion::Aprobada) {
-            $solicitudEntity = $this->solicitudes->obtenerPorId($apelacion->solicitud->id);
-            $this->solicitudes->actualizarEstado($solicitudEntity, EstadoSolicitud::Aprobada, $respuesta);
+            $solicitudEntity = $this->solicitudes->obtenerPorId(
+                new ObtenerSolicitudPorIdQuery(new SolicitudIdDTO($apelacion->solicitud->id))
+            );
+            $this->solicitudes->actualizarEstado(
+                new ActualizarEstadoSolicitudCommand(
+                    new ActualizarEstadoSolicitudDTO($apelacion->solicitud->id, EstadoSolicitud::Aprobada, $respuesta)
+                )
+            );
             $apelacion->refresh()->load('solicitud.estudiante.usuario');
         }
 

--- a/app/Presentation/Http/Controllers/Secretaria/SolicitudController.php
+++ b/app/Presentation/Http/Controllers/Secretaria/SolicitudController.php
@@ -2,7 +2,11 @@
 
 namespace App\Http\Controllers\ModuloSecretaria;
 
+use App\Application\Solicitudes\Commands\ActualizarEstadoSolicitudCommand;
+use App\Application\Solicitudes\DTOs\ActualizarEstadoSolicitudDTO;
+use App\Application\Solicitudes\DTOs\PaginarSolicitudesSecretariaDTO;
 use App\Application\Solicitudes\Handlers\SolicitudService;
+use App\Application\Solicitudes\Queries\PaginarSolicitudesSecretariaQuery;
 use App\Domain\Shared\Enums\EstadoSolicitud;
 use App\Http\Controllers\Controller;
 use App\Domain\Solicitud\Entities\Solicitud;
@@ -19,7 +23,11 @@ class SolicitudController extends Controller
         $estado = EstadoSolicitud::tryFrom($request->query('estado')) ?? EstadoSolicitud::Pendiente;
         $sinPendientes = $estado === EstadoSolicitud::Rechazada;
 
-        $solicitudes = $this->solicitudes->paginateForSecretaria($estado, $sinPendientes, 9);
+        $solicitudes = $this->solicitudes->paginateForSecretaria(
+            new PaginarSolicitudesSecretariaQuery(
+                new PaginarSolicitudesSecretariaDTO($estado, $sinPendientes, 9)
+            )
+        );
 
         return view('ModuloSecretaria.solicitudes.index', [
             'solicitudes' => $solicitudes,
@@ -47,9 +55,11 @@ class SolicitudController extends Controller
         $estado = EstadoSolicitud::from($request->input('estado'));
         $respuesta = $request->input('respuesta');
 
-        $solicitudEntity = $this->solicitudes->obtenerPorId($solicitud->id);
-
-        $this->solicitudes->actualizarEstado($solicitudEntity, $estado, $respuesta);
+        $this->solicitudes->actualizarEstado(
+            new ActualizarEstadoSolicitudCommand(
+                new ActualizarEstadoSolicitudDTO($solicitud->id, $estado, $respuesta)
+            )
+        );
 
         $redirectEstado = $request->query('estado', 'pendiente');
 


### PR DESCRIPTION
## Summary
- add DTOs plus command/query objects for solicitudes, apelaciones, reprogramaciones, and catálogo modules
- refactor corresponding application services to consume the new DTO-backed commands and queries
- update presentation controllers to construct and pass the new DTOs, aligning request handling with the refactored services

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_690550689880832e97d0126121d86e68