### PR TITLE
Introduce composite builder for appeal history

### DIFF
--- a/app/Domain/Apelaciones/Entities/Apelacion.php
+++ b/app/Domain/Apelaciones/Entities/Apelacion.php
@@ -2,6 +2,7 @@
 
 namespace App\Domain\Apelaciones\Entities;
 
+use App\Domain\Apelaciones\Tree\ApelacionHistorialBuilder;
 use App\Domain\Shared\Contracts\Entity;
 use App\Domain\Shared\Enums\EstadoApelacion;
 use App\Domain\Shared\ValueObjects\EntityId;
@@ -121,20 +122,17 @@ final class Apelacion implements Entity
      */
     public function historial(?string $respuestaInicial, array $cadena): array
     {
-        $historial = [];
+        $builder = new ApelacionHistorialBuilder();
 
-        if ($respuestaInicial) {
-            $historial[] = ['autor' => 'secretaria', 'mensaje' => trim($respuestaInicial)];
-        }
+        $data = array_map(
+            static fn(self $apelacion): array => [
+                'observacion' => $apelacion->observacion->value(),
+                'respuesta' => $apelacion->respuesta?->value(),
+            ],
+            $cadena
+        );
 
-        foreach ($cadena as $apelacion) {
-            $historial[] = ['autor' => 'estudiante', 'mensaje' => $apelacion->observacion->value()];
-            if ($apelacion->respuesta) {
-                $historial[] = ['autor' => 'secretaria', 'mensaje' => $apelacion->respuesta->value()];
-            }
-        }
-
-        return $historial;
+        return $builder->build($respuestaInicial, $data);
     }
 
     /**

--- a/app/Domain/Apelaciones/Tree/ApelacionComposite.php
+++ b/app/Domain/Apelaciones/Tree/ApelacionComposite.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Domain\Apelaciones\Tree;
+
+/**
+ * Composite que encapsula los mensajes asociados a una apelación y sus hijas.
+ */
+class ApelacionComposite extends HistorialComposite
+{
+    public function __construct(string $observacion, ?string $respuesta)
+    {
+        $this->add(new MensajeLeaf('estudiante', $observacion));
+
+        if ($respuesta !== null && trim($respuesta) !== '') {
+            $this->add(new MensajeLeaf('secretaria', $respuesta));
+        }
+    }
+}

--- a/app/Domain/Apelaciones/Tree/ApelacionHistorialBuilder.php
+++ b/app/Domain/Apelaciones/Tree/ApelacionHistorialBuilder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Domain\Apelaciones\Tree;
+
+final class ApelacionHistorialBuilder
+{
+    /**
+     * @param list<array{observacion:string,respuesta:?string}> $apelaciones
+     * @return list<array{autor:string,mensaje:string}>
+     */
+    public function build(?string $respuestaInicial, array $apelaciones): array
+    {
+        $root = new HistorialComposite();
+
+        if ($respuestaInicial !== null && trim($respuestaInicial) !== '') {
+            $root->add(new MensajeLeaf('secretaria', trim($respuestaInicial)));
+        }
+
+        $cursor = $root;
+
+        foreach ($apelaciones as $datos) {
+            $composite = new ApelacionComposite($datos['observacion'], $datos['respuesta']);
+            $cursor->add($composite);
+            $cursor = $composite;
+        }
+
+        return $root->historial();
+    }
+}

--- a/app/Domain/Apelaciones/Tree/HistorialComponent.php
+++ b/app/Domain/Apelaciones/Tree/HistorialComponent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Domain\Apelaciones\Tree;
+
+/**
+ * Representa cualquier componente dentro del historial de apelaciones.
+ */
+interface HistorialComponent
+{
+    /**
+     * @return list<array{autor:string,mensaje:string}>
+     */
+    public function historial(): array;
+}

--- a/app/Domain/Apelaciones/Tree/HistorialComposite.php
+++ b/app/Domain/Apelaciones/Tree/HistorialComposite.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Domain\Apelaciones\Tree;
+
+/**
+ * Nodo compuesto que orquesta la recopilación del historial desde sus hijos.
+ */
+class HistorialComposite implements HistorialComponent
+{
+    /**
+     * @var list<HistorialComponent>
+     */
+    private array $children = [];
+
+    public function add(HistorialComponent $component): void
+    {
+        $this->children[] = $component;
+    }
+
+    public function historial(): array
+    {
+        $historial = [];
+        foreach ($this->children as $child) {
+            foreach ($child->historial() as $entry) {
+                $historial[] = $entry;
+            }
+        }
+
+        return $historial;
+    }
+}

--- a/app/Domain/Apelaciones/Tree/MensajeLeaf.php
+++ b/app/Domain/Apelaciones/Tree/MensajeLeaf.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Domain\Apelaciones\Tree;
+
+/**
+ * Hoja que representa un mensaje puntual dentro del historial.
+ */
+class MensajeLeaf implements HistorialComponent
+{
+    public function __construct(
+        private readonly string $autor,
+        private readonly string $mensaje
+    ) {
+    }
+
+    public function historial(): array
+    {
+        return [[
+            'autor' => $this->autor,
+            'mensaje' => $this->mensaje,
+        ]];
+    }
+}

--- a/app/Models/ModuloEstudiante/Apelacion.php
+++ b/app/Models/ModuloEstudiante/Apelacion.php
@@ -2,9 +2,10 @@
 
 namespace App\Models\ModuloEstudiante;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Domain\Apelaciones\Tree\ApelacionHistorialBuilder;
 use App\Domain\Shared\Enums\EstadoApelacion;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 
 class Apelacion extends Model
 {
@@ -49,28 +50,18 @@ class Apelacion extends Model
      */
     public function historial(): array
     {
-        $historial = [];
-
         $cadena = [];
         $actual = $this;
         while ($actual) {
-            $cadena[] = $actual;
+            $cadena[] = [
+                'observacion' => $actual->observacion,
+                'respuesta' => $actual->respuesta,
+            ];
             $actual = $actual->apelacionPadre;
         }
-        $cadena = array_reverse($cadena);
 
-        $respuestaInicial = $this->solicitud->respuesta;
-        if ($respuestaInicial) {
-            $historial[] = ['autor' => 'secretaria', 'mensaje' => $respuestaInicial];
-        }
+        $builder = new ApelacionHistorialBuilder();
 
-        foreach ($cadena as $apelacion) {
-            $historial[] = ['autor' => 'estudiante', 'mensaje' => $apelacion->observacion];
-            if ($apelacion->respuesta) {
-                $historial[] = ['autor' => 'secretaria', 'mensaje' => $apelacion->respuesta];
-            }
-        }
-
-        return $historial;
+        return $builder->build($this->solicitud->respuesta, array_reverse($cadena));
     }
 }

--- a/tests/Unit/Domain/Apelaciones/ApelacionHistorialBuilderTest.php
+++ b/tests/Unit/Domain/Apelaciones/ApelacionHistorialBuilderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit\Domain\Apelaciones;
+
+use App\Domain\Apelaciones\Tree\ApelacionHistorialBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class ApelacionHistorialBuilderTest extends TestCase
+{
+    public function testBuildGeneratesChronologicalConversation(): void
+    {
+        $builder = new ApelacionHistorialBuilder();
+
+        $historial = $builder->build('Respuesta inicial', [
+            ['observacion' => 'Primera apelación', 'respuesta' => 'Primera respuesta'],
+            ['observacion' => 'Segunda apelación', 'respuesta' => null],
+            ['observacion' => 'Tercera apelación', 'respuesta' => 'Respuesta final'],
+        ]);
+
+        self::assertSame([
+            ['autor' => 'secretaria', 'mensaje' => 'Respuesta inicial'],
+            ['autor' => 'estudiante', 'mensaje' => 'Primera apelación'],
+            ['autor' => 'secretaria', 'mensaje' => 'Primera respuesta'],
+            ['autor' => 'estudiante', 'mensaje' => 'Segunda apelación'],
+            ['autor' => 'estudiante', 'mensaje' => 'Tercera apelación'],
+            ['autor' => 'secretaria', 'mensaje' => 'Respuesta final'],
+        ], $historial);
+    }
+}


### PR DESCRIPTION
## Summary
- add a composite structure to model appeal history conversations
- refactor the Eloquent model and domain entity to reuse the composite builder
- add a unit test covering the builder output order

## Testing
- ./vendor/bin/phpunit --filter ApelacionHistorialBuilderTest

------
https://chatgpt.com/codex/tasks/task_e_69056287e444832e8d38e48b8619de75