### PR TITLE
Implement event bus observers for solicitud and reprogramacion notifications

### DIFF
--- a/app/Application/Reprogramaciones/Events/ReprogramacionCreada.php
+++ b/app/Application/Reprogramaciones/Events/ReprogramacionCreada.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Application\Reprogramaciones\Events;
+
+use App\Domain\Reprogramacion\Entities\Reprogramacion;
+
+final class ReprogramacionCreada
+{
+    public function __construct(private readonly Reprogramacion $reprogramacion)
+    {
+    }
+
+    public function reprogramacion(): Reprogramacion
+    {
+        return $this->reprogramacion;
+    }
+}

--- a/app/Application/Reprogramaciones/Handlers/CrearReprogramacionHandler.php
+++ b/app/Application/Reprogramaciones/Handlers/CrearReprogramacionHandler.php
@@ -4,13 +4,11 @@ namespace App\Application\Reprogramaciones\Handlers;
 
 use App\Application\Reprogramaciones\Commands\CrearReprogramacionCommand;
 use App\Application\Reprogramaciones\Handlers\Concerns\ValidatesReprogramacionData;
-use App\Application\Shared\Contracts\Mailer;
-use App\Application\Shared\Mail\Notifications\ReprogramacionCreadaNotification;
+use App\Application\Shared\Event\EventBus;
+use App\Application\Reprogramaciones\Events\ReprogramacionCreada;
 use App\Domain\Reprogramacion\Entities\Reprogramacion;
 use App\Domain\Reprogramacion\Repositories\ReprogramacionRepository;
 use App\Domain\Solicitud\Repositories\SolicitudRepository;
-use App\Models\ModuloEstudiante\Solicitud as SolicitudModel;
-use Illuminate\Support\Carbon;
 use InvalidArgumentException;
 
 final class CrearReprogramacionHandler
@@ -20,7 +18,7 @@ final class CrearReprogramacionHandler
     public function __construct(
         private readonly ReprogramacionRepository $reprogramaciones,
         private readonly SolicitudRepository $solicitudes,
-        private readonly Mailer $mailer
+        private readonly EventBus $events
     ) {
     }
 
@@ -45,19 +43,7 @@ final class CrearReprogramacionHandler
 
         $reprogramacion = $this->reprogramaciones->create($entity);
 
-        $solicitudModel = SolicitudModel::with('estudiante.usuario')->find($solicitudId);
-
-        if ($solicitudModel) {
-            $studentUser = $solicitudModel->estudiante->usuario;
-
-            $this->mailer->queue(new ReprogramacionCreadaNotification(
-                $studentUser->name,
-                $studentUser->email,
-                Carbon::parse($reprogramacion->fecha()->format('Y-m-d'))->format('d-m-Y'),
-                $reprogramacion->hora()->value(),
-                $reprogramacion->observaciones()?->value()
-            ));
-        }
+        $this->events->publish(new ReprogramacionCreada($reprogramacion));
 
         return $reprogramacion;
     }

--- a/app/Application/Reprogramaciones/Observers/ReprogramacionCreadaMailerObserver.php
+++ b/app/Application/Reprogramaciones/Observers/ReprogramacionCreadaMailerObserver.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Application\Reprogramaciones\Observers;
+
+use App\Application\Reprogramaciones\Events\ReprogramacionCreada;
+use App\Application\Shared\Contracts\Mailer;
+use App\Application\Shared\Mail\Notifications\ReprogramacionCreadaNotification;
+use App\Models\ModuloEstudiante\Solicitud as SolicitudModel;
+use Illuminate\Support\Carbon;
+
+final class ReprogramacionCreadaMailerObserver
+{
+    public function __construct(private readonly Mailer $mailer)
+    {
+    }
+
+    public function __invoke(ReprogramacionCreada $event): void
+    {
+        $reprogramacion = $event->reprogramacion();
+        $solicitudModel = SolicitudModel::with('estudiante.usuario')->find($reprogramacion->solicitudId()->value());
+
+        if (! $solicitudModel) {
+            return;
+        }
+
+        $studentUser = $solicitudModel->estudiante->usuario;
+
+        $this->mailer->queue(new ReprogramacionCreadaNotification(
+            $studentUser->name,
+            $studentUser->email,
+            Carbon::parse($reprogramacion->fecha()->format('Y-m-d'))->format('d-m-Y'),
+            $reprogramacion->hora()->value(),
+            $reprogramacion->observaciones()?->value()
+        ));
+    }
+}

--- a/app/Application/Shared/Event/EventBus.php
+++ b/app/Application/Shared/Event/EventBus.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Application\Shared\Event;
+
+interface EventBus
+{
+    /**
+     * @param callable(object): void $listener
+     */
+    public function subscribe(string $eventName, callable $listener): void;
+
+    /**
+     * @param callable(object): void $listener
+     */
+    public function unsubscribe(string $eventName, callable $listener): void;
+
+    public function publish(object $event): void;
+}

--- a/app/Application/Solicitudes/Events/SolicitudEstadoActualizado.php
+++ b/app/Application/Solicitudes/Events/SolicitudEstadoActualizado.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Application\Solicitudes\Events;
+
+use App\Domain\Solicitud\Entities\Solicitud;
+
+final class SolicitudEstadoActualizado
+{
+    public function __construct(private readonly Solicitud $solicitud)
+    {
+    }
+
+    public function solicitud(): Solicitud
+    {
+        return $this->solicitud;
+    }
+}

--- a/app/Application/Solicitudes/Handlers/ActualizarEstadoSolicitudHandler.php
+++ b/app/Application/Solicitudes/Handlers/ActualizarEstadoSolicitudHandler.php
@@ -2,20 +2,17 @@
 
 namespace App\Application\Solicitudes\Handlers;
 
-use App\Application\Shared\Contracts\Mailer;
-use App\Application\Shared\Mail\Notifications\SolicitudAprobadaNotification;
-use App\Application\Shared\Mail\Notifications\SolicitudRechazadaNotification;
+use App\Application\Shared\Event\EventBus;
 use App\Application\Solicitudes\Commands\ActualizarEstadoSolicitudCommand;
-use App\Domain\Shared\Enums\EstadoSolicitud;
+use App\Application\Solicitudes\Events\SolicitudEstadoActualizado;
 use App\Domain\Solicitud\Entities\Solicitud;
 use App\Domain\Solicitud\Repositories\SolicitudRepository;
-use App\Models\ModuloEstudiante\Solicitud as SolicitudModel;
 
 final class ActualizarEstadoSolicitudHandler
 {
     public function __construct(
         private readonly SolicitudRepository $solicitudes,
-        private readonly Mailer $mailer
+        private readonly EventBus $events
     ) {
     }
 
@@ -27,49 +24,8 @@ final class ActualizarEstadoSolicitudHandler
 
         $actualizada = $this->solicitudes->update($solicitud);
 
-        $this->notificarCambioEstado($actualizada);
+        $this->events->publish(new SolicitudEstadoActualizado($actualizada));
 
         return $actualizada;
-    }
-
-    private function notificarCambioEstado(Solicitud $solicitud): void
-    {
-        $modelo = SolicitudModel::with(['estudiante.usuario', 'docente.usuario'])
-            ->find($solicitud->id()?->value());
-
-        if (! $modelo) {
-            return;
-        }
-
-        $studentUser = $modelo->estudiante->usuario;
-        $teacherUser = $modelo->docente->usuario;
-
-        if ($solicitud->estado() === EstadoSolicitud::Aprobada) {
-            $this->mailer->queue(new SolicitudAprobadaNotification(
-                $studentUser->name,
-                $studentUser->email
-            ));
-
-            $this->mailer->queue(new SolicitudAprobadaNotification(
-                $teacherUser->name,
-                $teacherUser->email
-            ));
-        }
-
-        if ($solicitud->estado() === EstadoSolicitud::Rechazada) {
-            $respuesta = $solicitud->respuesta()?->value();
-
-            $this->mailer->queue(new SolicitudRechazadaNotification(
-                $studentUser->name,
-                $studentUser->email,
-                $respuesta
-            ));
-
-            $this->mailer->queue(new SolicitudRechazadaNotification(
-                $teacherUser->name,
-                $teacherUser->email,
-                $respuesta
-            ));
-        }
     }
 }

--- a/app/Application/Solicitudes/Observers/SolicitudEstadoActualizadoMailerObserver.php
+++ b/app/Application/Solicitudes/Observers/SolicitudEstadoActualizadoMailerObserver.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Application\Solicitudes\Observers;
+
+use App\Application\Shared\Contracts\Mailer;
+use App\Application\Shared\Mail\Notifications\SolicitudAprobadaNotification;
+use App\Application\Shared\Mail\Notifications\SolicitudRechazadaNotification;
+use App\Application\Solicitudes\Events\SolicitudEstadoActualizado;
+use App\Domain\Shared\Enums\EstadoSolicitud;
+use App\Models\ModuloEstudiante\Solicitud as SolicitudModel;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+final class SolicitudEstadoActualizadoMailerObserver
+{
+    public function __construct(private readonly Mailer $mailer)
+    {
+    }
+
+    public function __invoke(SolicitudEstadoActualizado $event): void
+    {
+        $solicitud = $event->solicitud();
+        $solicitudId = $solicitud->id()?->value();
+
+        if ($solicitudId === null) {
+            return;
+        }
+
+        $modelo = SolicitudModel::with(['estudiante.usuario', 'docente.usuario'])->find($solicitudId);
+
+        if (! $modelo) {
+            return;
+        }
+
+        $recipients = array_filter([
+            $modelo->estudiante->usuario,
+            $modelo->docente->usuario,
+        ]);
+
+        if ($recipients === []) {
+            return;
+        }
+
+        $notificationFactory = match ($solicitud->estado()) {
+            EstadoSolicitud::Aprobada => static fn (Authenticatable $user) => new SolicitudAprobadaNotification(
+                $user->name,
+                $user->email
+            ),
+            EstadoSolicitud::Rechazada => function (Authenticatable $user) use ($solicitud) {
+                return new SolicitudRechazadaNotification(
+                    $user->name,
+                    $user->email,
+                    $solicitud->respuesta()?->value()
+                );
+            },
+            default => null,
+        };
+
+        if ($notificationFactory === null) {
+            return;
+        }
+
+        foreach ($recipients as $user) {
+            $this->mailer->queue($notificationFactory($user));
+        }
+    }
+}

--- a/app/Infrastructure/Event/InMemoryEventBus.php
+++ b/app/Infrastructure/Event/InMemoryEventBus.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Infrastructure\Event;
+
+use App\Application\Shared\Event\EventBus;
+
+final class InMemoryEventBus implements EventBus
+{
+    /**
+     * @var array<string, list<callable(object): void>>
+     */
+    private array $listeners = [];
+
+    public function subscribe(string $eventName, callable $listener): void
+    {
+        $this->listeners[$eventName][] = $listener;
+    }
+
+    public function unsubscribe(string $eventName, callable $listener): void
+    {
+        if (! isset($this->listeners[$eventName])) {
+            return;
+        }
+
+        $this->listeners[$eventName] = array_values(array_filter(
+            $this->listeners[$eventName],
+            static fn (callable $registered): bool => $registered !== $listener
+        ));
+
+        if ($this->listeners[$eventName] === []) {
+            unset($this->listeners[$eventName]);
+        }
+    }
+
+    public function publish(object $event): void
+    {
+        $eventName = $event::class;
+
+        foreach ($this->listeners[$eventName] ?? [] as $listener) {
+            $listener($event);
+        }
+    }
+}

--- a/app/Infrastructure/Providers/InfrastructureServiceProvider.php
+++ b/app/Infrastructure/Providers/InfrastructureServiceProvider.php
@@ -5,6 +5,11 @@ namespace App\Infrastructure\Providers;
 use App\Application\Shared\Contracts\FileStorage;
 use App\Application\Shared\Contracts\Mailer;
 use App\Application\Shared\Contracts\TransactionManager;
+use App\Application\Shared\Event\EventBus;
+use App\Application\Reprogramaciones\Events\ReprogramacionCreada;
+use App\Application\Reprogramaciones\Observers\ReprogramacionCreadaMailerObserver;
+use App\Application\Solicitudes\Events\SolicitudEstadoActualizado;
+use App\Application\Solicitudes\Observers\SolicitudEstadoActualizadoMailerObserver;
 use App\Domain\Apelaciones\Repositories\ApelacionRepository;
 use App\Domain\Catalogo\Repositories\AsignaturaRepository;
 use App\Domain\Catalogo\Repositories\CarreraRepository;
@@ -15,6 +20,7 @@ use App\Domain\Reprogramacion\Repositories\ReprogramacionRepository;
 use App\Domain\Solicitud\Repositories\SolicitudRepository;
 use App\Infraestructure\Files\PublicDiskFileStorage;
 use App\Infrastructure\Mail\LaravelMailer;
+use App\Infrastructure\Event\InMemoryEventBus;
 use App\Infrastructure\Persistence\DatabaseTransactionManager;
 use App\Infraestructure\Persistence\Eloquent\Repositories\EloquentApelacionRepository;
 use App\Infraestructure\Persistence\Eloquent\Repositories\EloquentAsignaturaRepository;
@@ -48,9 +54,21 @@ class InfrastructureServiceProvider extends ServiceProvider
 
         $this->app->bind(Mailer::class, LaravelMailer::class);
         $this->app->bind(TransactionManager::class, DatabaseTransactionManager::class);
+        $this->app->singleton(EventBus::class, InMemoryEventBus::class);
     }
 
     public function boot(): void
     {
+        $bus = $this->app->make(EventBus::class);
+
+        $bus->subscribe(
+            SolicitudEstadoActualizado::class,
+            $this->app->make(SolicitudEstadoActualizadoMailerObserver::class)
+        );
+
+        $bus->subscribe(
+            ReprogramacionCreada::class,
+            $this->app->make(ReprogramacionCreadaMailerObserver::class)
+        );
     }
 }

--- a/tests/Unit/Application/Shared/Event/InMemoryEventBusTest.php
+++ b/tests/Unit/Application/Shared/Event/InMemoryEventBusTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Unit\Application\Shared\Event;
+
+use App\Infrastructure\Event\InMemoryEventBus;
+use PHPUnit\Framework\TestCase;
+
+final class InMemoryEventBusTest extends TestCase
+{
+    public function testPublishNotifiesSubscribedListeners(): void
+    {
+        $bus = new InMemoryEventBus();
+        $event = new DummyEvent();
+        $received = 0;
+
+        $listener = function (DummyEvent $emitted) use (&$received, $event): void {
+            if ($emitted === $event) {
+                $received++;
+            }
+        };
+
+        $bus->subscribe(DummyEvent::class, $listener);
+        $bus->publish($event);
+
+        self::assertSame(1, $received);
+
+        $bus->unsubscribe(DummyEvent::class, $listener);
+        $bus->publish(new DummyEvent());
+
+        self::assertSame(1, $received, 'Listener should not be triggered after unsubscribe.');
+    }
+}
+
+final class DummyEvent
+{
+}


### PR DESCRIPTION
## Summary
- add a lightweight event bus contract and in-memory implementation for synchronous observers
- emit events from solicitud status updates and reprogramacion creation handlers and move mail logic into observers
- wire observers in the infrastructure provider and add a regression test covering subscription, publication, and unsubscription

## Testing
- `./vendor/bin/phpunit --testdox` *(fails: existing suite expects seeded factories and app key that are absent in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6905716d3db8832e9e27761ca481db22