### PR TITLE
Refactor solicitud state notifications

### DIFF
--- a/app/Application/Solicitudes/Handlers/ActualizarEstadoSolicitudHandler.php
+++ b/app/Application/Solicitudes/Handlers/ActualizarEstadoSolicitudHandler.php
@@ -3,8 +3,11 @@
 namespace App\Application\Solicitudes\Handlers;
 
 use App\Application\Shared\Contracts\Mailer;
-use App\Application\Shared\Mail\Notifications\SolicitudAprobadaNotification;
-use App\Application\Shared\Mail\Notifications\SolicitudRechazadaNotification;
+use App\Application\Solicitudes\Notifications\SolicitudAprobadaNotifier;
+use App\Application\Solicitudes\Notifications\SolicitudEstadoNotifier;
+use App\Application\Solicitudes\Notifications\SolicitudRechazadaNotifier;
+use App\Application\Solicitudes\Notifications\SolicitudSinNotificacionNotifier;
+use App\Application\Solicitudes\Notifications\ValueObjects\SolicitudNotificacionContext;
 use App\Application\Solicitudes\Commands\ActualizarEstadoSolicitudCommand;
 use App\Domain\Shared\Enums\EstadoSolicitud;
 use App\Domain\Solicitud\Entities\Solicitud;
@@ -13,10 +16,21 @@ use App\Models\ModuloEstudiante\Solicitud as SolicitudModel;
 
 final class ActualizarEstadoSolicitudHandler
 {
+    /** @var array<string, SolicitudEstadoNotifier> */
+    private array $notificadoresPorEstado;
+
+    private readonly SolicitudEstadoNotifier $notificadorPorDefecto;
+
     public function __construct(
         private readonly SolicitudRepository $solicitudes,
         private readonly Mailer $mailer
     ) {
+        $this->notificadoresPorEstado = [
+            EstadoSolicitud::Aprobada->value => new SolicitudAprobadaNotifier($mailer),
+            EstadoSolicitud::Rechazada->value => new SolicitudRechazadaNotifier($mailer),
+        ];
+
+        $this->notificadorPorDefecto = new SolicitudSinNotificacionNotifier();
     }
 
     public function handle(ActualizarEstadoSolicitudCommand $command): Solicitud
@@ -44,32 +58,19 @@ final class ActualizarEstadoSolicitudHandler
         $studentUser = $modelo->estudiante->usuario;
         $teacherUser = $modelo->docente->usuario;
 
-        if ($solicitud->estado() === EstadoSolicitud::Aprobada) {
-            $this->mailer->queue(new SolicitudAprobadaNotification(
-                $studentUser->name,
-                $studentUser->email
-            ));
+        $context = new SolicitudNotificacionContext(
+            $studentUser->name,
+            $studentUser->email,
+            $teacherUser->name,
+            $teacherUser->email,
+            $solicitud->respuesta()?->value()
+        );
 
-            $this->mailer->queue(new SolicitudAprobadaNotification(
-                $teacherUser->name,
-                $teacherUser->email
-            ));
-        }
+        $this->resolverNotificador($solicitud->estado())->notify($context);
+    }
 
-        if ($solicitud->estado() === EstadoSolicitud::Rechazada) {
-            $respuesta = $solicitud->respuesta()?->value();
-
-            $this->mailer->queue(new SolicitudRechazadaNotification(
-                $studentUser->name,
-                $studentUser->email,
-                $respuesta
-            ));
-
-            $this->mailer->queue(new SolicitudRechazadaNotification(
-                $teacherUser->name,
-                $teacherUser->email,
-                $respuesta
-            ));
-        }
+    private function resolverNotificador(EstadoSolicitud $estado): SolicitudEstadoNotifier
+    {
+        return $this->notificadoresPorEstado[$estado->value] ?? $this->notificadorPorDefecto;
     }
 }

--- a/app/Application/Solicitudes/Notifications/SolicitudAprobadaNotifier.php
+++ b/app/Application/Solicitudes/Notifications/SolicitudAprobadaNotifier.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Application\Solicitudes\Notifications;
+
+use App\Application\Shared\Contracts\Mailer;
+use App\Application\Shared\Mail\Notifications\SolicitudAprobadaNotification;
+use App\Application\Solicitudes\Notifications\ValueObjects\SolicitudNotificacionContext;
+
+final class SolicitudAprobadaNotifier implements SolicitudEstadoNotifier
+{
+    public function __construct(private readonly Mailer $mailer)
+    {
+    }
+
+    public function notify(SolicitudNotificacionContext $context): void
+    {
+        $this->mailer->queue(new SolicitudAprobadaNotification(
+            $context->studentName(),
+            $context->studentEmail()
+        ));
+
+        $this->mailer->queue(new SolicitudAprobadaNotification(
+            $context->teacherName(),
+            $context->teacherEmail()
+        ));
+    }
+}

--- a/app/Application/Solicitudes/Notifications/SolicitudEstadoNotifier.php
+++ b/app/Application/Solicitudes/Notifications/SolicitudEstadoNotifier.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Application\Solicitudes\Notifications;
+
+use App\Application\Solicitudes\Notifications\ValueObjects\SolicitudNotificacionContext;
+
+interface SolicitudEstadoNotifier
+{
+    public function notify(SolicitudNotificacionContext $context): void;
+}

--- a/app/Application/Solicitudes/Notifications/SolicitudRechazadaNotifier.php
+++ b/app/Application/Solicitudes/Notifications/SolicitudRechazadaNotifier.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Application\Solicitudes\Notifications;
+
+use App\Application\Shared\Contracts\Mailer;
+use App\Application\Shared\Mail\Notifications\SolicitudRechazadaNotification;
+use App\Application\Solicitudes\Notifications\ValueObjects\SolicitudNotificacionContext;
+
+final class SolicitudRechazadaNotifier implements SolicitudEstadoNotifier
+{
+    public function __construct(private readonly Mailer $mailer)
+    {
+    }
+
+    public function notify(SolicitudNotificacionContext $context): void
+    {
+        $this->mailer->queue(new SolicitudRechazadaNotification(
+            $context->studentName(),
+            $context->studentEmail(),
+            $context->respuesta()
+        ));
+
+        $this->mailer->queue(new SolicitudRechazadaNotification(
+            $context->teacherName(),
+            $context->teacherEmail(),
+            $context->respuesta()
+        ));
+    }
+}

--- a/app/Application/Solicitudes/Notifications/SolicitudSinNotificacionNotifier.php
+++ b/app/Application/Solicitudes/Notifications/SolicitudSinNotificacionNotifier.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Application\Solicitudes\Notifications;
+
+use App\Application\Solicitudes\Notifications\ValueObjects\SolicitudNotificacionContext;
+
+final class SolicitudSinNotificacionNotifier implements SolicitudEstadoNotifier
+{
+    public function notify(SolicitudNotificacionContext $context): void
+    {
+        // Intentionally left blank: algunos estados no requieren notificaciones.
+    }
+}

--- a/app/Application/Solicitudes/Notifications/ValueObjects/SolicitudNotificacionContext.php
+++ b/app/Application/Solicitudes/Notifications/ValueObjects/SolicitudNotificacionContext.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Application\Solicitudes\Notifications\ValueObjects;
+
+final class SolicitudNotificacionContext
+{
+    public function __construct(
+        private readonly string $studentName,
+        private readonly string $studentEmail,
+        private readonly string $teacherName,
+        private readonly string $teacherEmail,
+        private readonly ?string $respuesta
+    ) {
+    }
+
+    public function studentName(): string
+    {
+        return $this->studentName;
+    }
+
+    public function studentEmail(): string
+    {
+        return $this->studentEmail;
+    }
+
+    public function teacherName(): string
+    {
+        return $this->teacherName;
+    }
+
+    public function teacherEmail(): string
+    {
+        return $this->teacherEmail;
+    }
+
+    public function respuesta(): ?string
+    {
+        return $this->respuesta;
+    }
+}

--- a/tests/Unit/Application/Solicitudes/Notifications/SolicitudEstadoNotifierTest.php
+++ b/tests/Unit/Application/Solicitudes/Notifications/SolicitudEstadoNotifierTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Unit\Application\Solicitudes\Notifications;
+
+use App\Application\Shared\Contracts\Mailer;
+use App\Application\Shared\Mail\MailNotification;
+use App\Application\Shared\Mail\Notifications\SolicitudAprobadaNotification;
+use App\Application\Shared\Mail\Notifications\SolicitudRechazadaNotification;
+use App\Application\Solicitudes\Notifications\SolicitudAprobadaNotifier;
+use App\Application\Solicitudes\Notifications\SolicitudRechazadaNotifier;
+use App\Application\Solicitudes\Notifications\SolicitudSinNotificacionNotifier;
+use App\Application\Solicitudes\Notifications\ValueObjects\SolicitudNotificacionContext;
+use PHPUnit\Framework\TestCase;
+
+final class SolicitudEstadoNotifierTest extends TestCase
+{
+    public function test_aprobada_notifier_envia_notificaciones_para_estudiante_y_docente(): void
+    {
+        $mailer = new FakeMailer();
+        $notifier = new SolicitudAprobadaNotifier($mailer);
+
+        $context = new SolicitudNotificacionContext(
+            'Estudiante Ejemplo',
+            'estudiante@example.com',
+            'Docente Ejemplo',
+            'docente@example.com',
+            null
+        );
+
+        $notifier->notify($context);
+
+        $this->assertCount(2, $mailer->queued);
+        $this->assertInstanceOf(SolicitudAprobadaNotification::class, $mailer->queued[0]);
+        $this->assertSame('Estudiante Ejemplo', $mailer->queued[0]->recipientName());
+        $this->assertInstanceOf(SolicitudAprobadaNotification::class, $mailer->queued[1]);
+        $this->assertSame('Docente Ejemplo', $mailer->queued[1]->recipientName());
+    }
+
+    public function test_rechazada_notifier_incluye_observaciones_en_ambos_destinatarios(): void
+    {
+        $mailer = new FakeMailer();
+        $notifier = new SolicitudRechazadaNotifier($mailer);
+
+        $context = new SolicitudNotificacionContext(
+            'Estudiante Ejemplo',
+            'estudiante@example.com',
+            'Docente Ejemplo',
+            'docente@example.com',
+            'Observaciones de rechazo'
+        );
+
+        $notifier->notify($context);
+
+        $this->assertCount(2, $mailer->queued);
+        $this->assertInstanceOf(SolicitudRechazadaNotification::class, $mailer->queued[0]);
+        $this->assertSame('Observaciones de rechazo', $mailer->queued[0]->observaciones());
+        $this->assertInstanceOf(SolicitudRechazadaNotification::class, $mailer->queued[1]);
+        $this->assertSame('Observaciones de rechazo', $mailer->queued[1]->observaciones());
+    }
+
+    public function test_sin_notificacion_notifier_no_envia_correos(): void
+    {
+        $mailer = new FakeMailer();
+        $notifier = new SolicitudSinNotificacionNotifier();
+
+        $context = new SolicitudNotificacionContext(
+            'Estudiante Ejemplo',
+            'estudiante@example.com',
+            'Docente Ejemplo',
+            'docente@example.com',
+            null
+        );
+
+        $notifier->notify($context);
+
+        $this->assertEmpty($mailer->queued);
+    }
+}
+
+/**
+ * @internal
+ */
+final class FakeMailer implements Mailer
+{
+    /** @var list<MailNotification> */
+    public array $queued = [];
+
+    public function queue(MailNotification $notification): void
+    {
+        $this->queued[] = $notification;
+    }
+}


### PR DESCRIPTION
## Summary
- extract state-specific notification classes for solicitudes
- wire handler to delegate notification behavior to state objects
- cover notification flows with unit tests

## Testing
- ./vendor/bin/phpunit --filter SolicitudEstadoNotifierTest

------
https://chatgpt.com/codex/tasks/task_e_690563f018c4832e9c0d9b412b20e403